### PR TITLE
Fix invalid .NET Core SDK used in Dockerfile

### DIFF
--- a/DOCKERFILE
+++ b/DOCKERFILE
@@ -1,5 +1,5 @@
 # Build image
-FROM microsoft/dotnet:2.1-sdk AS builder
+FROM microsoft/dotnet:2.2-sdk AS builder
 WORKDIR /app
 
 # Copy files
@@ -12,7 +12,7 @@ WORKDIR /app/Sample/EventSourcing.Sample.Web
 RUN dotnet publish -c Debug -o out
 
 # Build runtime image
-FROM microsoft/dotnet:2.1-sdk
+FROM microsoft/dotnet:2.2-sdk
 WORKDIR /app
 COPY --from=builder /app/Sample/EventSourcing.Sample.Web/out .
 ENV ASPNETCORE_URLS="http://*:5000"


### PR DESCRIPTION
Upgrade DOCKERFILE .NET Core SDK container to .NET Core 2.2