### PR TITLE
Fix bug using incorrect type in append_event

### DIFF
--- a/Workshop/01-EventStoreBasics/07-AggregateAndRepository/EventStore.cs
+++ b/Workshop/01-EventStoreBasics/07-AggregateAndRepository/EventStore.cs
@@ -137,7 +137,7 @@ namespace EventStoreBasics
         private void CreateAppendEventFunction()
         {
             const string AppendEventFunctionSQL =
-                @"CREATE OR REPLACE FUNCTION append_event(id uuid, data text, type text, stream_id uuid, stream_type text, expected_stream_version bigint default null) RETURNS boolean
+                @"CREATE OR REPLACE FUNCTION append_event(id uuid, data jsonb, type text, stream_id uuid, stream_type text, expected_stream_version bigint default null) RETURNS boolean
                 LANGUAGE plpgsql
                 AS $$
                 DECLARE


### PR DESCRIPTION
07-AggregateAndRepository/EventStore.cs has a bug in the EventStore::CreateAppendEventFunction where the creation of the postgres function uses the wrong type. It uses text but is should instead use jsonb.