### PR TITLE
Fix link to: "Events should be as small as possible, right?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Events:
 
 Read more in my articles:
 -   📝 [What's the difference between a command and an event?](https://event-driven.io/en/whats_the_difference_between_event_and_command/?utm_source=event_sourcing_net)
--   📝 [Events should be as small as possible, right?](https://event-driven.io/en/whats_the_difference_between_event_and_command/?utm_source=event_sourcing_net)
+-   📝 [Events should be as small as possible, right?](https://event-driven.io/en/events_should_be_as_small_as_possible/?utm_source=event_sourcing_net)
 
 ### 1.3 What is Stream?
 


### PR DESCRIPTION
Fix link that points to wrong article.