### PR TITLE
Convert ConfigureShipmentsModule to use IApplicationBuilder.

### DIFF
--- a/Sample/ECommerce/Shipments/Shipments.Api/Startup.cs
+++ b/Sample/ECommerce/Shipments/Shipments.Api/Startup.cs
@@ -64,7 +64,7 @@ namespace Shipments.Api
                 c.RoutePrefix = string.Empty;
             });
 
-            app.ApplicationServices.ConfigureShipmentsModule();
+            app.ConfigureShipmentsModule();
         }
     }
 }

--- a/Sample/ECommerce/Shipments/Shipments/Config.cs
+++ b/Sample/ECommerce/Shipments/Shipments/Config.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,13 +25,14 @@ namespace Shipments
                 options => options.UseNpgsql("name=ConnectionStrings:ShipmentsDatabase"));
         }
 
-        public static void ConfigureShipmentsModule(this IServiceProvider serviceProvider)
+        public static void ConfigureShipmentsModule(this IApplicationBuilder app)
         {
             var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Development";
 
             if (environment == "Development")
             {
-                serviceProvider.GetRequiredService<ShipmentsDbContext>().Database.Migrate();
+                using var serviceScope = app.ApplicationServices.CreateScope();
+                serviceScope.ServiceProvider.GetRequiredService<ShipmentsDbContext>().Database.Migrate();
             }
         }
     }


### PR DESCRIPTION
During startup, ApplicationServices was not able to resolve the reference to ShipmentsDbContext. Using IApplicationBuilder and creating a new scope from app.ApplicationServices seems to have to addressed the issue.

Fixes #60 