### PR TITLE
Split build.dotnet.yaml into two workflows

### DIFF
--- a/.github/workflows/build.dotnet.testreport.yml
+++ b/.github/workflows/build.dotnet.testreport.yml
@@ -7,16 +7,16 @@ on:
       - completed
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Tests Results
+          artifact: test-results
+          reporter: dotnet-trx
+          path: '**/test-results.trx'
+          fail-on-error: 'false'
 
-        steps:
-            - name: Publish test results
-              uses: dorny/test-reporter@v1
-              if: success() || failure()
-              with:
-                name: Tests Results
-                artifact: test-results
-                reporter: dotnet-trx
-                path: '**/test-results.trx'
-                fail-on-error: 'false'

--- a/.github/workflows/build.dotnet.testreport.yml
+++ b/.github/workflows/build.dotnet.testreport.yml
@@ -1,0 +1,22 @@
+name: Test Report
+
+on:
+  workflow_run:
+    workflows: ['Build and Test']
+    types:
+      - completed
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Publish test results
+              uses: dorny/test-reporter@v1
+              if: success() || failure()
+              with:
+                name: Tests Results
+                artifact: test-results
+                reporter: dotnet-trx
+                path: '**/test-results.trx'
+                fail-on-error: 'false'

--- a/.github/workflows/build.dotnet.yml
+++ b/.github/workflows/build.dotnet.yml
@@ -31,12 +31,11 @@ jobs:
             - name: Run tests
               run: dotnet test --configuration Release --no-build --filter Category!=SkipCI --logger "trx;LogFileName=test-results.trx"
 
-            - name: Publish test results
-              uses: dorny/test-reporter@v1
+            - name: Upload test results
+              uses: actions/upload-artifact@v2
               if: success() || failure()
               with:
-                name: Tests Results
-                reporter: dotnet-trx
+                name: test-results
                 path: '**/test-results.trx'
                 fail-on-error: 'false'
 


### PR DESCRIPTION
Tests were failing on pull requests from forked repositories.  This appears to stem from the way GitHub handles workflows triggered by pull requests.

A note on the [dorny/test-reporter](https://github.com/dorny/test-reporter) says
> Workflows triggered by pull requests from forked repositories are executed with read-only token and therefore can't create check runs. To workaround this security restriction, it's required to use two separate workflows.

Changes were made based on the author's [Recommended setup for public repositories](https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories)

Fixes #63
