### PR TITLE
Change Package.SentAt date to be DateTime.UtcNow

### DIFF
--- a/Sample/ECommerce/Shipments/Shipments/Packages/PackageService.cs
+++ b/Sample/ECommerce/Shipments/Shipments/Packages/PackageService.cs
@@ -65,7 +65,7 @@ namespace Shipments.Packages
                 OrderId = request.OrderId,
                 ProductItems = request.ProductItems.Select(pi =>
                     new ProductItem {Id = Guid.NewGuid(), ProductId = pi.ProductId, Quantity = pi.Quantity}).ToList(),
-                SentAt = DateTime.Now
+                SentAt = DateTime.UtcNow
             };
 
             await Packages.AddAsync(package, cancellationToken);


### PR DESCRIPTION
Two Shipment.Api tests, CreateCommand_ShouldCreate_Package and CreateCommand_ShouldPublish_PackageWasSentEvent were failing as they expecting SentAt to be after the fixture's TimeBeforeSending.  TimeBeforeSending was set to DateTime.UtcNow while the Package.SentAt was DateTime.Now.  This caused the tests to fail due to time zone discrepancies.

Fixes #62 