### PR TITLE
Add applicationUrl to ECommerce Sample APIs

### DIFF
--- a/Sample/ECommerce/Carts/Carts.Api/Properties/launchSettings.json
+++ b/Sample/ECommerce/Carts/Carts.Api/Properties/launchSettings.json
@@ -11,6 +11,7 @@
         "CartsApi": {
             "commandName": "Project",
             "launchBrowser": true,
+            "applicationUrl": "http://localhost:5500",
             "launchUrl": "http://localhost:5500",
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Sample/ECommerce/Orders/Orders.Api/Properties/launchSettings.json
+++ b/Sample/ECommerce/Orders/Orders.Api/Properties/launchSettings.json
@@ -11,6 +11,7 @@
         "OrdersApi": {
             "commandName": "Project",
             "launchBrowser": true,
+            "applicationUrl": "http://localhost:5501",
             "launchUrl": "http://localhost:5501",
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Sample/ECommerce/Payments/Payments.Api/Properties/launchSettings.json
+++ b/Sample/ECommerce/Payments/Payments.Api/Properties/launchSettings.json
@@ -11,6 +11,7 @@
         "PaymentsApi": {
             "commandName": "Project",
             "launchBrowser": true,
+            "applicationUrl": "http://localhost:5502",
             "launchUrl": "http://localhost:5502",
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Sample/ECommerce/Shipments/Shipments.Api/Properties/launchSettings.json
+++ b/Sample/ECommerce/Shipments/Shipments.Api/Properties/launchSettings.json
@@ -11,6 +11,7 @@
         "ShipmentsApi": {
             "commandName": "Project",
             "launchBrowser": true,
+            "applicationUrl": "http://localhost:5503",
             "launchUrl": "http://localhost:5503",
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
The launchUrls indicated the APIs should have different ports assigned.
However, since no applicationUrl was provided, they all ran on port 5000
(and 5001 for https)

Fix #67 