### PR TITLE
Added Marten Outbox Pattern/Subscription with custom Projection

### DIFF
--- a/CQRS.Tests/CQRS.Tests.csproj
+++ b/CQRS.Tests/CQRS.Tests.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="SharpTestsEx" Version="2.0.0" />

--- a/Core.Api.Testing/ApiFixture.cs
+++ b/Core.Api.Testing/ApiFixture.cs
@@ -48,6 +48,7 @@ public abstract class ApiFixture: IAsyncLifetime
         return Task.CompletedTask;
     }
 
+    // TODO: Add Poly here
     public async Task<HttpResponseMessage> Get(string path = "", int maxNumberOfRetries = 0,
         int retryIntervalInMs = 1000, Func<HttpResponseMessage, ValueTask<bool>>? check = null)
     {

--- a/Core.ElasticSearch/Indices/IndexNameMapper.cs
+++ b/Core.ElasticSearch/Indices/IndexNameMapper.cs
@@ -18,7 +18,7 @@ public class IndexNameMapper
 
     public static string ToIndexPrefix<TStream>() => ToIndexPrefix(typeof(TStream));
 
-    public static string ToIndexPrefix(Type streamType) => Instance.typeNameMap.GetOrAdd(streamType, (_) =>
+    public static string ToIndexPrefix(Type streamType) => Instance.typeNameMap.GetOrAdd(streamType, _ =>
     {
         var modulePrefix = streamType.Namespace!.Split(".").First();
         return $"{modulePrefix}-{streamType.Name}".ToLower();

--- a/Core.EventStoreDB/Subscriptions/EventStoreDBSubscriptionToAll.cs
+++ b/Core.EventStoreDB/Subscriptions/EventStoreDBSubscriptionToAll.cs
@@ -23,7 +23,7 @@ public class EventStoreDBSubscriptionToAllOptions
 
 public class EventStoreDBSubscriptionToAll
 {
-    private readonly INoMediatorEventBus noMediatorEventBus;
+    private readonly INoMediatorEventBus eventBus;
     private readonly EventStoreClient eventStoreClient;
     private readonly ISubscriptionCheckpointRepository checkpointRepository;
     private readonly ILogger<EventStoreDBSubscriptionToAll> logger;
@@ -34,12 +34,12 @@ public class EventStoreDBSubscriptionToAll
 
     public EventStoreDBSubscriptionToAll(
         EventStoreClient eventStoreClient,
-        INoMediatorEventBus noMediatorEventBus,
+        INoMediatorEventBus eventBus,
         ISubscriptionCheckpointRepository checkpointRepository,
         ILogger<EventStoreDBSubscriptionToAll> logger
     )
     {
-        this.noMediatorEventBus = noMediatorEventBus ?? throw new ArgumentNullException(nameof(noMediatorEventBus));
+        this.eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
         this.eventStoreClient = eventStoreClient ?? throw new ArgumentNullException(nameof(eventStoreClient));
         this.checkpointRepository =
             checkpointRepository ?? throw new ArgumentNullException(nameof(checkpointRepository));
@@ -98,7 +98,7 @@ public class EventStoreDBSubscriptionToAll
             }
 
             // publish event to internal event bus
-            await noMediatorEventBus.Publish(streamEvent, ct);
+            await eventBus.Publish(streamEvent, ct);
 
             await checkpointRepository.Store(SubscriptionId, resolvedEvent.Event.Position.CommitPosition, ct);
         }

--- a/Core.Kafka/Producers/KafkaProducer.cs
+++ b/Core.Kafka/Producers/KafkaProducer.cs
@@ -26,7 +26,7 @@ public class KafkaProducer: IExternalEventProducer
         using var p = new ProducerBuilder<string, string>(config.ProducerConfig).Build();
         await Task.Yield();
         // publish event to kafka topic taken from config
-        var result = await p.ProduceAsync(config.Topic,
+        await p.ProduceAsync(config.Topic,
             new Message<string, string>
             {
                 // store event type name in message Key

--- a/Core.Marten/Core.Marten.csproj
+++ b/Core.Marten/Core.Marten.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/Core.Marten/Repository/MartenRepository.cs
+++ b/Core.Marten/Repository/MartenRepository.cs
@@ -15,15 +15,12 @@ public interface IMartenRepository<T> where T : class, IAggregate
 public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggregate
 {
     private readonly IDocumentSession documentSession;
-    private readonly IEventBus eventBus;
 
     public MartenRepository(
-        IDocumentSession documentSession,
-        IEventBus eventBus
+        IDocumentSession documentSession
     )
     {
         this.documentSession = documentSession;
-        this.eventBus = eventBus;
     }
 
     public Task<T?> Find(Guid id, CancellationToken cancellationToken) =>
@@ -39,7 +36,6 @@ public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggrega
         );
 
         await documentSession.SaveChangesAsync(cancellationToken);
-        await eventBus.Publish(events, cancellationToken);
 
         return events.Length;
     }
@@ -59,7 +55,6 @@ public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggrega
         );
 
         await documentSession.SaveChangesAsync(cancellationToken);
-        await eventBus.Publish(events, cancellationToken);
 
         return nextVersion;
     }

--- a/Core.Marten/Subscriptions/MartenEventPublisher.cs
+++ b/Core.Marten/Subscriptions/MartenEventPublisher.cs
@@ -1,0 +1,42 @@
+﻿using Core.Events;
+using Marten;
+using Marten.Events;
+using Microsoft.Extensions.DependencyInjection;
+using IEvent = Core.Events.IEvent;
+
+namespace Core.Marten.Subscriptions;
+
+public class MartenEventPublisher: IMartenEventsConsumer
+{
+    private readonly IServiceProvider serviceProvider;
+
+    public MartenEventPublisher(
+        IServiceProvider serviceProvider
+    )
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+    public async Task ConsumeAsync(IDocumentOperations documentOperations, IReadOnlyList<StreamAction> streamActions,
+        CancellationToken ct)
+    {
+        foreach (var @event in streamActions.SelectMany(streamAction => streamAction.Events))
+        {
+            // TODO: align all handlers to use StreamEvent
+            // var streamEvent = new StreamEvent(
+            //     @event.Data,
+            //     new EventMetadata(
+            //         (ulong)@event.Version,
+            //         (ulong)@event.Sequence
+            //     )
+            // );
+
+            using var scope = serviceProvider.CreateScope();
+            var eventBus = scope.ServiceProvider.GetRequiredService<IEventBus>();
+
+            if (@event.Data is not IEvent mappedEvent) continue;
+
+            await eventBus.Publish(mappedEvent, ct);
+        }
+    }
+}

--- a/Core.Marten/Subscriptions/MartenSubscription.cs
+++ b/Core.Marten/Subscriptions/MartenSubscription.cs
@@ -1,0 +1,43 @@
+﻿using Marten;
+using Marten.Events;
+using Marten.Events.Projections;
+
+namespace Core.Marten.Subscriptions;
+
+public class MartenSubscription: IProjection
+{
+    private readonly IEnumerable<IMartenEventsConsumer> consumers;
+
+    public MartenSubscription(IEnumerable<IMartenEventsConsumer> consumers)
+    {
+        this.consumers = consumers;
+    }
+
+    public void Apply(
+        IDocumentOperations operations,
+        IReadOnlyList<StreamAction> streams
+    ) =>
+        throw new NotImplementedException("Subscriptions should work only in the async scope");
+
+    public async Task ApplyAsync(
+        IDocumentOperations operations,
+        IReadOnlyList<StreamAction> streams,
+        CancellationToken ct
+    )
+    {
+        foreach (var consumer in consumers)
+        {
+            await consumer.ConsumeAsync(operations, streams, ct);
+        }
+    }
+}
+
+
+public interface IMartenEventsConsumer
+{
+    Task ConsumeAsync(
+        IDocumentOperations documentOperations,
+        IReadOnlyList<StreamAction> streamActions,
+        CancellationToken ct
+    );
+}

--- a/Core.Tests/Core.Tests.csproj
+++ b/Core.Tests/Core.Tests.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />
         <PackageReference Include="SharpTestsEx" Version="2.0.0" />

--- a/Core.WebApi/Tracing/Correlation/CorrelationIdMiddleware.cs
+++ b/Core.WebApi/Tracing/Correlation/CorrelationIdMiddleware.cs
@@ -15,16 +15,14 @@ public class CorrelationIdMiddleware
 
     private readonly RequestDelegate next;
     private readonly ILogger<CorrelationIdMiddleware> logger;
-    private readonly Func<CorrelationId> correlationIdFactory;
 
-    public CorrelationIdMiddleware(RequestDelegate next, ILogger<CorrelationIdMiddleware> logger, Func<CorrelationId> correlationIdFactory)
+    public CorrelationIdMiddleware(RequestDelegate next, ILogger<CorrelationIdMiddleware> logger)
     {
         this.next = next ?? throw new ArgumentNullException(nameof(next));
         this.logger = logger;
-        this.correlationIdFactory = correlationIdFactory;
     }
 
-    public async Task Invoke(HttpContext context)
+    public async Task Invoke(HttpContext context, Func<CorrelationId> correlationIdFactory)
     {
         // get correlation id from header or generate a new one
         context.TraceIdentifier =
@@ -54,8 +52,8 @@ public static class CorrelationIdMiddlewareConfig
 {
     public static IServiceCollection AddCorrelationIdMiddleware(this IServiceCollection services)
     {
-        services.TryAddScoped<ICorrelationIdFactory, GuidCorrelationIdFactory>();
         services.TryAddScoped<Func<CorrelationId>>(sp => sp.GetRequiredService<ICorrelationIdFactory>().New);
+        services.TryAddScoped<ICorrelationIdFactory, GuidCorrelationIdFactory>();
 
         return services;
     }

--- a/EventSourcing.Integration.Tests/EventSourcing.Integration.Tests.csproj
+++ b/EventSourcing.Integration.Tests/EventSourcing.Integration.Tests.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />

--- a/Marten.Integration.Tests/Marten.Integration.Tests.csproj
+++ b/Marten.Integration.Tests/Marten.Integration.Tests.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="SharpTestsEx" Version="2.0.0" />

--- a/MediatR.Tests/MediatR.Tests.csproj
+++ b/MediatR.Tests/MediatR.Tests.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />

--- a/Sample/AsyncProjections/SmartHome.Temperature/MotionSensors/RebuildingMotionSensorsViews/RebuildMotionSensorsViews.cs
+++ b/Sample/AsyncProjections/SmartHome.Temperature/MotionSensors/RebuildingMotionSensorsViews/RebuildMotionSensorsViews.cs
@@ -20,10 +20,8 @@ public class HandleRebuildMotionSensorsViews :
 
     public async Task<Unit> Handle(RebuildMotionSensorsViews command, CancellationToken cancellationToken)
     {
-        using (var daemon = session.DocumentStore.BuildProjectionDaemon())
-        {
-            await daemon.RebuildProjection<MotionSensor>(cancellationToken);
-        }
+        using var daemon = await session.DocumentStore.BuildProjectionDaemonAsync();
+        await daemon.RebuildProjection<MotionSensor>(cancellationToken);
         return Unit.Value;
     }
 }

--- a/Sample/ECommerce/Carts/Carts.Api.Tests/Settings.cs
+++ b/Sample/ECommerce/Carts/Carts.Api.Tests/Settings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Sample/ECommerce/Orders/Orders.Api.Tests/Orders/InitializingOrder/InitializeOrderTests.cs
+++ b/Sample/ECommerce/Orders/Orders.Api.Tests/Orders/InitializingOrder/InitializeOrderTests.cs
@@ -16,8 +16,8 @@ public class InitializeOrderFixture: ApiWithEventsFixture<Startup>
 
     public readonly List<PricedProductItemRequest> ProductItems = new()
     {
-        new PricedProductItemRequest {ProductId = Guid.NewGuid(), Quantity = 10, UnitPrice = 3},
-        new PricedProductItemRequest {ProductId = Guid.NewGuid(), Quantity = 3, UnitPrice = 7}
+        new PricedProductItemRequest { ProductId = Guid.NewGuid(), Quantity = 10, UnitPrice = 3 },
+        new PricedProductItemRequest { ProductId = Guid.NewGuid(), Quantity = 3, UnitPrice = 7 }
     };
 
     public decimal TotalPrice => ProductItems.Sum(pi => pi.Quantity!.Value * pi.UnitPrice!.Value);
@@ -64,18 +64,17 @@ public class InitializeOrderTests: IClassFixture<InitializeOrderFixture>
     {
         var createdId = await fixture.CommandResponse.GetResultFromJson<Guid>();
 
-        fixture.PublishedInternalEventsOfType<OrderInitialized>()
-            .Should()
-            .HaveCount(1)
-            .And.Contain(@event =>
+        await fixture.ShouldPublishInternalEventOfType<OrderInitialized>(
+            @event =>
                 @event.OrderId == createdId
                 && @event.ClientId == fixture.ClientId
                 && @event.InitializedAt > fixture.TimeBeforeSending
                 && @event.ProductItems.Count == fixture.ProductItems.Count
                 && @event.ProductItems.All(
                     pi => fixture.ProductItems.Exists(
-                        expi => expi.ProductId == pi.ProductId && expi.Quantity == pi.Quantity))
-            );
+                        expi => expi.ProductId == pi.ProductId && expi.Quantity == pi.Quantity)
+                    )
+        );
     }
 
     // [Fact]

--- a/Sample/ECommerce/Orders/Orders.Api.Tests/Settings.cs
+++ b/Sample/ECommerce/Orders/Orders.Api.Tests/Settings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Sample/ECommerce/Payments/Payments.Api.Tests/Payments/RequestingPayment/RequestPaymentsTests.cs
+++ b/Sample/ECommerce/Payments/Payments.Api.Tests/Payments/RequestingPayment/RequestPaymentsTests.cs
@@ -54,10 +54,8 @@ public class RequestPaymentsTestsTests: IClassFixture<RequestPaymentsTestsFixtur
     {
         var createdId = await fixture.CommandResponse.GetResultFromJson<Guid>();
 
-        fixture.PublishedInternalEventsOfType<PaymentRequested>()
-            .Should()
-            .HaveCount(1)
-            .And.Contain(@event =>
+        await fixture.ShouldPublishInternalEventOfType<PaymentRequested>(
+            @event =>
                 @event.PaymentId == createdId
                 && @event.OrderId == fixture.OrderId
                 && @event.Amount == fixture.Amount

--- a/Sample/ECommerce/Payments/Payments.Api.Tests/Settings.cs
+++ b/Sample/ECommerce/Payments/Payments.Api.Tests/Settings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Sample/ECommerce/Shipments/Shipments.Api.Tests/Packages/SendPackageTests.cs
+++ b/Sample/ECommerce/Shipments/Shipments.Api.Tests/Packages/SendPackageTests.cs
@@ -20,16 +20,8 @@ public class SendPackageFixture: ApiWithEventsFixture<Startup>
 
     public readonly List<ProductItem> ProductItems = new()
     {
-        new ProductItem
-        {
-            ProductId = Guid.NewGuid(),
-            Quantity = 10
-        },
-        new ProductItem
-        {
-            ProductId = Guid.NewGuid(),
-            Quantity = 3
-        }
+        new ProductItem { ProductId = Guid.NewGuid(), Quantity = 10 },
+        new ProductItem { ProductId = Guid.NewGuid(), Quantity = 3 }
     };
 
     public HttpResponseMessage CommandResponse = default!;
@@ -67,10 +59,8 @@ public class SendPackageTests: IClassFixture<SendPackageFixture>
     {
         var createdId = await fixture.CommandResponse.GetResultFromJson<Guid>();
 
-        fixture.PublishedInternalEventsOfType<PackageWasSent>()
-            .Should()
-            .HaveCount(1)
-            .And.Contain(@event =>
+        await fixture.ShouldPublishInternalEventOfType<PackageWasSent>(
+            @event =>
                 @event.PackageId == createdId
                 && @event.OrderId == fixture.OrderId
                 && @event.SentAt > fixture.TimeBeforeSending
@@ -78,7 +68,7 @@ public class SendPackageTests: IClassFixture<SendPackageFixture>
                 && @event.ProductItems.All(
                     pi => fixture.ProductItems.Exists(
                         expi => expi.ProductId == pi.ProductId && expi.Quantity == pi.Quantity))
-            );
+        );
     }
 
     [Fact]

--- a/Sample/ECommerce/Shipments/Shipments.Api.Tests/Settings.cs
+++ b/Sample/ECommerce/Shipments/Shipments.Api.Tests/Settings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts.Api.Tests/Settings.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts.Api.Tests/Settings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Sample/MeetingsManagement/MeetingsManagement.Api/MeetingsManagement.Api.csproj
+++ b/Sample/MeetingsManagement/MeetingsManagement.Api/MeetingsManagement.Api.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />

--- a/Sample/MeetingsManagement/MeetingsManagement.Api/Startup.cs
+++ b/Sample/MeetingsManagement/MeetingsManagement.Api/Startup.cs
@@ -35,8 +35,8 @@ public class Startup
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "Meeting Management", Version = "v1" });
                 c.OperationFilter<MetadataOperationFilter>();
             })
-            .AddCoreServices()
             .AddKafkaProducerAndConsumer()
+            .AddCoreServices()
             .AddMeetingsManagement(config)
             .AddCorrelationIdMiddleware()
             .AddOptimisticConcurrencyMiddleware(

--- a/Sample/MeetingsManagement/MeetingsManagement.IntegrationTests/Meetings/CreatingMeeting/CreateMeetingTests.cs
+++ b/Sample/MeetingsManagement/MeetingsManagement.IntegrationTests/Meetings/CreatingMeeting/CreateMeetingTests.cs
@@ -58,8 +58,8 @@ public class CreateMeetingTests: IClassFixture<CreateMeetingFixture>
     public void CreateCommand_ShouldPublish_MeetingCreateEvent()
     {
         // assert MeetingCreated event was produced to external bus
-        fixture.PublishedExternalEventsOfType<MeetingCreated>()
-            .Should().Contain(@event =>
+        fixture.ShouldPublishInternalEventOfType<MeetingCreated>(
+            @event =>
                 @event.MeetingId == fixture.MeetingId
                 && @event.Name == fixture.MeetingName
             );

--- a/Sample/MeetingsManagement/MeetingsManagement.IntegrationTests/MeetingsManagement.IntegrationTests.csproj
+++ b/Sample/MeetingsManagement/MeetingsManagement.IntegrationTests/MeetingsManagement.IntegrationTests.csproj
@@ -13,7 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Sample/MeetingsManagement/MeetingsManagement.IntegrationTests/Settings.cs
+++ b/Sample/MeetingsManagement/MeetingsManagement.IntegrationTests/Settings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Sample/MeetingsManagement/MeetingsManagement/MeetingsManagement.csproj
+++ b/Sample/MeetingsManagement/MeetingsManagement/MeetingsManagement.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="JsonNet.PrivateSettersContractResolvers" Version="1.0.0" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/Sample/MeetingsManagement/MeetingsSearch.Api/Startup.cs
+++ b/Sample/MeetingsManagement/MeetingsSearch.Api/Startup.cs
@@ -28,8 +28,9 @@ public class Startup
             c.OperationFilter<MetadataOperationFilter>();
         });
 
-        services.AddCoreServices()
+        services
             .AddKafkaConsumer()
+            .AddCoreServices()
             .AddMeetingsSearch(config)
             .AddCorrelationIdMiddleware();
     }

--- a/Sample/MeetingsManagement/MeetingsSearch.IntegrationTests/MeetingsSearch.IntegrationTests.csproj
+++ b/Sample/MeetingsManagement/MeetingsSearch.IntegrationTests/MeetingsSearch.IntegrationTests.csproj
@@ -13,7 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Sample/MeetingsManagement/MeetingsSearch.IntegrationTests/Settings.cs
+++ b/Sample/MeetingsManagement/MeetingsSearch.IntegrationTests/Settings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Sample/Tickets/Tickets.Api.Tests/Reservations/CreatingTentativeReservation/CreateTentativeReservationTests.cs
+++ b/Sample/Tickets/Tickets.Api.Tests/Reservations/CreatingTentativeReservation/CreateTentativeReservationTests.cs
@@ -28,7 +28,7 @@ public class CreateTentativeReservationFixture: ApiWithEventsFixture<Startup>
     public override async Task InitializeAsync()
     {
         // send create command
-        CommandResponse = await Post(new CreateTentativeReservationRequest {SeatId = SeatId});
+        CommandResponse = await Post(new CreateTentativeReservationRequest { SeatId = SeatId });
     }
 }
 
@@ -60,14 +60,12 @@ public class CreateTentativeReservationTests: IClassFixture<CreateTentativeReser
     {
         var createdReservationId = await fixture.CommandResponse.GetResultFromJson<Guid>();
 
-        fixture.PublishedInternalEventsOfType<TentativeReservationCreated>()
-            .Should()
-            .HaveCount(1)
-            .And.Contain(@event =>
+        await fixture.ShouldPublishInternalEventOfType<TentativeReservationCreated>(
+            @event =>
                 @event.ReservationId == createdReservationId
                 && @event.SeatId == fixture.SeatId
                 && !string.IsNullOrEmpty(@event.Number)
-            );
+        );
     }
 
     [Fact]
@@ -83,7 +81,7 @@ public class CreateTentativeReservationTests: IClassFixture<CreateTentativeReser
         var queryResponse = await fixture.Get(query);
         queryResponse.EnsureSuccessStatusCode();
 
-        var reservationDetails =  await queryResponse.GetResultFromJson<ReservationDetails>();
+        var reservationDetails = await queryResponse.GetResultFromJson<ReservationDetails>();
         reservationDetails.Id.Should().Be(createdReservationId);
         reservationDetails.Number.Should().NotBeNull().And.NotBeEmpty();
         reservationDetails.Status.Should().Be(ReservationStatus.Tentative);

--- a/Sample/Tickets/Tickets.Api.Tests/Settings.cs
+++ b/Sample/Tickets/Tickets.Api.Tests/Settings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Sample/Tickets/Tickets.Tests/Tickets.Tests.csproj
+++ b/Sample/Tickets/Tickets.Tests/Tickets.Tests.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Sample/Tickets/Tickets/Maintenance/MaintenanceCommandHandler.cs
+++ b/Sample/Tickets/Tickets/Maintenance/MaintenanceCommandHandler.cs
@@ -17,7 +17,7 @@ public class MaintenanceCommandHandler:
 
     public async Task<Unit> Handle(RebuildProjection command, CancellationToken cancellationToken)
     {
-        using var daemon = documentStore.BuildProjectionDaemon();
+        using var daemon = await documentStore.BuildProjectionDaemonAsync();
         await daemon.RebuildProjection(command.ViewName, cancellationToken);
 
         return Unit.Value;

--- a/Workshops/BuildYourOwnEventStore/01-CreateStreamsTable/01-CreateStreamsTable.csproj
+++ b/Workshops/BuildYourOwnEventStore/01-CreateStreamsTable/01-CreateStreamsTable.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/02-CreateEventsTable/02-CreateEventsTable.csproj
+++ b/Workshops/BuildYourOwnEventStore/02-CreateEventsTable/02-CreateEventsTable.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/03-CreateAppendEventFunction/03-CreateAppendEventFunction.csproj
+++ b/Workshops/BuildYourOwnEventStore/03-CreateAppendEventFunction/03-CreateAppendEventFunction.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/03-OptimisticConcurrency/03-OptimisticConcurrency.csproj
+++ b/Workshops/BuildYourOwnEventStore/03-OptimisticConcurrency/03-OptimisticConcurrency.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/04-EventStoreMethods/04-EventStoreMethods.csproj
+++ b/Workshops/BuildYourOwnEventStore/04-EventStoreMethods/04-EventStoreMethods.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/05-StreamAggregation/05-StreamAggregation.csproj
+++ b/Workshops/BuildYourOwnEventStore/05-StreamAggregation/05-StreamAggregation.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/06-TimeTraveling/06-TimeTraveling.csproj
+++ b/Workshops/BuildYourOwnEventStore/06-TimeTraveling/06-TimeTraveling.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/07-AggregateAndRepository/07-AggregateAndRepository.csproj
+++ b/Workshops/BuildYourOwnEventStore/07-AggregateAndRepository/07-AggregateAndRepository.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/08-Snapshots/08-Snapshots.csproj
+++ b/Workshops/BuildYourOwnEventStore/08-Snapshots/08-Snapshots.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/09-Projections/09-Projections.csproj
+++ b/Workshops/BuildYourOwnEventStore/09-Projections/09-Projections.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/10-ProjectionsWithMarten/10-ProjectionsWithMarten.csproj
+++ b/Workshops/BuildYourOwnEventStore/10-ProjectionsWithMarten/10-ProjectionsWithMarten.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/EventStoreBasics.Tests/EventStoreBasics.Tests.csproj
+++ b/Workshops/BuildYourOwnEventStore/EventStoreBasics.Tests/EventStoreBasics.Tests.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Workshops/BuildYourOwnEventStore/EventStoreBasics/EventStoreBasics.csproj
+++ b/Workshops/BuildYourOwnEventStore/EventStoreBasics/EventStoreBasics.csproj
@@ -7,7 +7,7 @@
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-      <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+      <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Simple.Migrations" Version="0.9.21" />
     </ItemGroup>

--- a/Workshops/BuildYourOwnEventStore/Tools/Tools.csproj
+++ b/Workshops/BuildYourOwnEventStore/Tools/Tools.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="Marten" Version="5.0.0-alpha.5" />
+        <PackageReference Include="Marten" Version="5.0.0-alpha.6" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Simple.Migrations" Version="0.9.21" />
         <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Added Marten Outbox Pattern/Subscription with custom Projection Plugged it into samples removing calling EventBus from the repository, by that getting at-least-once processing guarantee.

Read more about that in: https://event-driven.io/en/integrating_Marten/.

Other changes:
- Updated Marten to latest v5 alpha
- Disabled API tests parallelisation until better test setup is provided

Note: it will be good to align that with ESDB processing by using `StreamEvent` eventually.