### PR TITLE
Added missing logic in TracingMiddleware to actually get correlation and causation ids from request headers

### DIFF
--- a/Core.WebApi/Swagger/MetadataOperationFilter.cs
+++ b/Core.WebApi/Swagger/MetadataOperationFilter.cs
@@ -27,7 +27,7 @@ public class MetadataOperationFilter: IOperationFilter
 
         operation.Parameters.Add(new OpenApiParameter
         {
-            Name = "X-CorrelationId",
+            Name = "X-Correlation-ID",
             In = ParameterLocation.Header,
             Description = "Correlation Id",
             Required = false
@@ -35,7 +35,7 @@ public class MetadataOperationFilter: IOperationFilter
 
         operation.Parameters.Add(new OpenApiParameter
         {
-            Name = "X-CausationId",
+            Name = "X-Causation-ID",
             In = ParameterLocation.Header,
             Description = "Causation Id",
             Required = false

--- a/Core.WebApi/Tracing/TracingHeadersExtensions.cs
+++ b/Core.WebApi/Tracing/TracingHeadersExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Core.Tracing.Causation;
+using Core.Tracing.Correlation;
+using Microsoft.AspNetCore.Http;
+
+namespace Core.WebApi.Tracing;
+
+public static class TracingHeadersExtensions
+{
+    private const string CorrelationIdHeaderName = "X-Correlation-ID";
+    private const string CausationIdHeaderName = "X-Causation-ID";
+
+    public static CorrelationId? GetCorrelationId(this HttpRequest request) =>
+        request.Headers.TryGetValue(CorrelationIdHeaderName, out var correlationId)
+            ? new CorrelationId(correlationId)
+            : null;
+
+
+    public static CausationId? GetCausationId(this HttpRequest request) =>
+        request.Headers.TryGetValue(CausationIdHeaderName, out var correlationId)
+            ? new CausationId(correlationId)
+            : null;
+
+    public static void SetCorrelationId(this HttpResponse response, CorrelationId correlationId) =>
+        response.Headers.Add(CorrelationIdHeaderName, new[] { correlationId.Value });
+
+
+    public static void SetCausationId(this HttpResponse response, CausationId causationId) =>
+        response.Headers.Add(CausationIdHeaderName, new[] { causationId.Value });
+
+
+}

--- a/Core.WebApi/Tracing/TracingMiddleware.cs
+++ b/Core.WebApi/Tracing/TracingMiddleware.cs
@@ -1,4 +1,5 @@
-﻿using Core.Tracing;
+﻿using Core.Events;
+using Core.Tracing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,32 +11,34 @@ namespace Core.WebApi.Tracing;
 
 public class TracingMiddleware
 {
-    private const string CorrelationIdHeaderName = "X-Correlation-ID";
-    private const string CausationIdHeaderName = "X-Causation-ID";
-
     private readonly RequestDelegate next;
-    private readonly ILogger<TracingMiddleware> logger;
 
     public TracingMiddleware(RequestDelegate next, ILogger<TracingMiddleware> logger)
     {
         this.next = next ?? throw new ArgumentNullException(nameof(next));
-        this.logger = logger;
     }
 
     public async Task Invoke(
         HttpContext context,
-        Func<IServiceProvider, TracingScope> createTracingScope
+        Func<IServiceProvider, TraceMetadata?, TracingScope> createTracingScope
     )
     {
-        using var tracingScope = createTracingScope(context.RequestServices);
+        var traceMetadataFromHeaders = new TraceMetadata(
+            context.Request.GetCorrelationId(),
+            context.Request.GetCausationId()
+        );
+        using var tracingScope = createTracingScope(context.RequestServices, traceMetadataFromHeaders);
+
         var correlationId = tracingScope.CorrelationId;
         var causationId = tracingScope.CausationId;
+
+        context.TraceIdentifier = correlationId.Value;
 
         // apply the correlation ID to the response header for client side tracking
         context.Response.OnStarting(() =>
         {
-            context.Response.Headers.Add(CorrelationIdHeaderName, new[] { correlationId.Value });
-            context.Response.Headers.Add(CausationIdHeaderName, new[] { causationId.Value });
+            context.Response.SetCorrelationId(correlationId);
+            context.Response.SetCausationId(causationId);
             return Task.CompletedTask;
         });
 

--- a/Core/Config.cs
+++ b/Core/Config.cs
@@ -41,9 +41,9 @@ public static class Config
         services.TryAddScoped<ITraceMetadataProvider, TraceMetadataProvider>();
         services.TryAddScoped<ITracingScopeFactory, TracingScopeFactory>();
 
-        services.TryAddScoped<Func<IServiceProvider, TracingScope>>(sp =>
-            scopedServiceProvider =>
-                sp.GetRequiredService<ITracingScopeFactory>().CreateTraceScope(scopedServiceProvider)
+        services.TryAddScoped<Func<IServiceProvider, TraceMetadata?, TracingScope>>(sp =>
+            (scopedServiceProvider, traceMetadata) =>
+                sp.GetRequiredService<ITracingScopeFactory>().CreateTraceScope(scopedServiceProvider, traceMetadata)
         );
 
         services.TryAddScoped<Func<IServiceProvider, EventEnvelope?, TracingScope>>(sp =>

--- a/Core/Tracing/TracingScope.cs
+++ b/Core/Tracing/TracingScope.cs
@@ -69,7 +69,8 @@ public class TracingScopeFactory: ITracingScopeFactory
 
 public static class TraceScopeFactoryExtensions
 {
-    public static TracingScope CreateTraceScope(this ITracingScopeFactory tracingScopeFactory,
+    public static TracingScope CreateTraceScope(
+        this ITracingScopeFactory tracingScopeFactory,
         IServiceProvider serviceProvider, EventEnvelope? eventEnvelope)
     {
         if (eventEnvelope == null)


### PR DESCRIPTION
A follow-up PR to https://github.com/oskardudycz/EventSourcing.NetCore/pull/106