### PR TITLE
Updated MartenEventPublisher to publish events with metadata. 

### DIFF
--- a/Core.ElasticSearch/Projections/ElasticSearchProjection.cs
+++ b/Core.ElasticSearch/Projections/ElasticSearchProjection.cs
@@ -9,7 +9,7 @@ namespace Core.ElasticSearch.Projections;
 
 public class ElasticSearchProjection<TEvent, TView> : IEventHandler<EventEnvelope<TEvent>>
     where TView : class, IProjection
-    where TEvent : IEvent
+    where TEvent : notnull
 {
     private readonly IElasticClient elasticClient;
     private readonly Func<TEvent, string> getId;
@@ -46,7 +46,7 @@ public static class ElasticSearchProjectionConfig
     public static IServiceCollection Project<TEvent, TView>(this IServiceCollection services,
         Func<TEvent, string> getId)
         where TView : class, IProjection
-        where TEvent : IEvent
+        where TEvent : notnull
     {
         services.AddTransient<IEventHandler<EventEnvelope<TEvent>>>(sp =>
         {

--- a/Core.ElasticSearch/Repository/ElasticSearchRepository.cs
+++ b/Core.ElasticSearch/Repository/ElasticSearchRepository.cs
@@ -1,5 +1,4 @@
 using Core.ElasticSearch.Indices;
-using Core.Events;
 using Nest;
 using IAggregate = Core.Aggregates.IAggregate;
 

--- a/Core.EventStoreDB.Tests/Events/EventStoreDBEventMetadataJsonConverterTests.cs
+++ b/Core.EventStoreDB.Tests/Events/EventStoreDBEventMetadataJsonConverterTests.cs
@@ -1,5 +1,4 @@
-﻿using Core.Events;
-using Core.EventStoreDB.Events;
+﻿using Core.EventStoreDB.Events;
 using Core.Tracing;
 using Core.Tracing.Causation;
 using Core.Tracing.Correlation;

--- a/Core.EventStoreDB/Events/EventStoreDBEventMetadataJsonConverter.cs
+++ b/Core.EventStoreDB/Events/EventStoreDBEventMetadataJsonConverter.cs
@@ -1,5 +1,4 @@
-﻿using Core.Events;
-using Core.Tracing;
+﻿using Core.Tracing;
 using Core.Tracing.Causation;
 using Core.Tracing.Correlation;
 using Newtonsoft.Json;

--- a/Core.EventStoreDB/Subscriptions/EventStoreDBSubscriptionCheckpointRepository.cs
+++ b/Core.EventStoreDB/Subscriptions/EventStoreDBSubscriptionCheckpointRepository.cs
@@ -1,10 +1,9 @@
-﻿using Core.Events;
-using Core.EventStoreDB.Serialization;
+﻿using Core.EventStoreDB.Serialization;
 using EventStore.Client;
 
 namespace Core.EventStoreDB.Subscriptions;
 
-public record CheckpointStored(string SubscriptionId, ulong? Position, DateTime CheckpointedAt): IEvent;
+public record CheckpointStored(string SubscriptionId, ulong? Position, DateTime CheckpointedAt);
 
 public class EventStoreDBSubscriptionCheckpointRepository: ISubscriptionCheckpointRepository
 {

--- a/Core.Kafka/Config.cs
+++ b/Core.Kafka/Config.cs
@@ -1,4 +1,5 @@
 using Core.BackgroundWorkers;
+using Core.Events;
 using Core.Events.External;
 using Core.Kafka.Consumers;
 using Core.Kafka.Producers;
@@ -13,7 +14,10 @@ public static class Config
     public static IServiceCollection AddKafkaProducer(this IServiceCollection services)
     {
         //using TryAdd to support mocking, without that it won't be possible to override in tests
-        services.TryAddScoped<IExternalEventProducer, KafkaProducer>();
+        services.TryAddSingleton<IExternalEventProducer, KafkaProducer>();
+        services.AddSingleton<IEventBus>(sp =>
+            new EventBusDecoratorWithExternalProducer(sp.GetRequiredService<EventBus>(),
+                sp.GetRequiredService<IExternalEventProducer>()));
         return services;
     }
 

--- a/Core.Serialization/Newtonsoft/SerializationExtensions.cs
+++ b/Core.Serialization/Newtonsoft/SerializationExtensions.cs
@@ -53,7 +53,8 @@ public static class SerializationExtensions
     /// <returns>json string</returns>
     public static string ToJson(this object obj)
     {
-        return JsonConvert.SerializeObject(obj);
+        return JsonConvert.SerializeObject(obj,
+            new JsonSerializerSettings().WithNonDefaultConstructorContractResolver());
     }
 
     /// <summary>

--- a/Core.Testing/AggregateExtensions.cs
+++ b/Core.Testing/AggregateExtensions.cs
@@ -5,7 +5,7 @@ namespace Core.Testing;
 
 public static class AggregateExtensions
 {
-    public static T? PublishedEvent<T>(this IAggregate aggregate) where T : class, IEvent
+    public static T? PublishedEvent<T>(this IAggregate aggregate) where T : class
     {
         return aggregate.DequeueUncommittedEvents().LastOrDefault() as T;
     }

--- a/Core.Testing/DummyExternalEventPublisher.cs
+++ b/Core.Testing/DummyExternalEventPublisher.cs
@@ -5,11 +5,11 @@ namespace Core.Testing;
 
 public class DummyExternalEventProducer: IExternalEventProducer
 {
-    public IList<IExternalEvent> PublishedEvents { get; } = new List<IExternalEvent>();
+    public IList<object> PublishedEvents { get; } = new List<object>();
 
-    public Task Publish(IExternalEvent @event, CancellationToken ct)
+    public Task Publish(EventEnvelope @event, CancellationToken ct)
     {
-        PublishedEvents.Add(@event);
+        PublishedEvents.Add(@event.Data);
 
         return Task.CompletedTask;
     }

--- a/Core.Testing/EventListener.cs
+++ b/Core.Testing/EventListener.cs
@@ -4,11 +4,11 @@ namespace Core.Testing;
 
 public class EventsLog
 {
-    public List<IEvent> PublishedEvents { get; } = new();
+    public List<object> PublishedEvents { get; } = new();
 }
 
 public class EventListener<TEvent>: IEventHandler<TEvent>
-    where TEvent : IEvent
+    where TEvent : notnull
 {
     private readonly EventsLog eventsLog;
 

--- a/Core.WebApi/Tracing/TracingMiddleware.cs
+++ b/Core.WebApi/Tracing/TracingMiddleware.cs
@@ -1,5 +1,4 @@
-﻿using Core.Events;
-using Core.Tracing;
+﻿using Core.Tracing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/Core/Aggregates/Aggregate.cs
+++ b/Core/Aggregates/Aggregate.cs
@@ -1,5 +1,3 @@
-using Core.Events;
-
 namespace Core.Aggregates;
 
 public abstract class Aggregate: Aggregate<Guid>, IAggregate
@@ -12,11 +10,11 @@ public abstract class Aggregate<T>: IAggregate<T> where T : notnull
 
     public int Version { get; protected set; }
 
-    [NonSerialized] private readonly Queue<IEvent> uncommittedEvents = new();
+    [NonSerialized] private readonly Queue<object> uncommittedEvents = new();
 
     public virtual void When(object @event) { }
 
-    public IEvent[] DequeueUncommittedEvents()
+    public object[] DequeueUncommittedEvents()
     {
         var dequeuedEvents = uncommittedEvents.ToArray();
 
@@ -25,7 +23,7 @@ public abstract class Aggregate<T>: IAggregate<T> where T : notnull
         return dequeuedEvents;
     }
 
-    protected void Enqueue(IEvent @event)
+    protected void Enqueue(object @event)
     {
         uncommittedEvents.Enqueue(@event);
     }

--- a/Core/Aggregates/IAggregate.cs
+++ b/Core/Aggregates/IAggregate.cs
@@ -1,4 +1,3 @@
-using Core.Events;
 using Core.Projections;
 
 namespace Core.Aggregates;
@@ -12,5 +11,5 @@ public interface IAggregate<out T>: IProjection
     T Id { get; }
     int Version { get; }
 
-    IEvent[] DequeueUncommittedEvents();
+    object[] DequeueUncommittedEvents();
 }

--- a/Core/Config.cs
+++ b/Core/Config.cs
@@ -1,6 +1,5 @@
 using Core.Commands;
 using Core.Events;
-using Core.Events.External;
 using Core.Ids;
 using Core.Queries;
 using Core.Requests;
@@ -23,14 +22,12 @@ public static class Config
             .AddTracing()
             .AddEventBus();
 
-        services.TryAddScoped<IExternalEventProducer, NulloExternalEventProducer>();
         services.TryAddScoped<IExternalCommandBus, ExternalCommandBus>();
 
         services.TryAddScoped<IIdGenerator, NulloIdGenerator>();
 
         return services;
     }
-
 
     public static IServiceCollection AddTracing(this IServiceCollection services)
     {

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Polly" Version="7.2.3" />
         <PackageReference Include="RestSharp" Version="107.3.0" />
+        <PackageReference Include="Scrutor" Version="3.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Core/Events/Config.cs
+++ b/Core/Events/Config.cs
@@ -7,7 +7,6 @@ public static class Config
     public static IServiceCollection AddEventHandler<TEvent, TEventHandler>(
         this IServiceCollection services
     )
-        where TEvent : IEvent
         where TEventHandler : class, IEventHandler<TEvent>
     {
         return services

--- a/Core/Events/EventEnvelope.cs
+++ b/Core/Events/EventEnvelope.cs
@@ -12,7 +12,7 @@ public record EventMetadata(
 public record EventEnvelope(
     object Data,
     EventMetadata Metadata
-): IEvent;
+);
 
 public record EventEnvelope<T>(
     T Data,

--- a/Core/Events/External/IExternaEventProducer.cs
+++ b/Core/Events/External/IExternaEventProducer.cs
@@ -2,5 +2,31 @@ namespace Core.Events.External;
 
 public interface IExternalEventProducer
 {
-    Task Publish(IExternalEvent @event, CancellationToken ct);
+    Task Publish(EventEnvelope @event, CancellationToken ct);
+}
+
+
+public class EventBusDecoratorWithExternalProducer: IEventBus
+{
+    private readonly IEventBus eventBus;
+    private readonly IExternalEventProducer externalEventProducer;
+
+    public EventBusDecoratorWithExternalProducer(
+        IEventBus eventBus,
+        IExternalEventProducer externalEventProducer
+    )
+    {
+        this.eventBus = eventBus;
+        this.externalEventProducer = externalEventProducer;
+    }
+
+    public async Task Publish(object @event, CancellationToken ct)
+    {
+        await eventBus.Publish(@event, ct);
+
+        if (@event is EventEnvelope { Data: IExternalEvent } eventEnvelope)
+        {
+            await externalEventProducer.Publish(eventEnvelope, ct);
+        }
+    }
 }

--- a/Core/Events/External/NulloExternalEventProducer.cs
+++ b/Core/Events/External/NulloExternalEventProducer.cs
@@ -2,7 +2,7 @@ namespace Core.Events.External;
 
 public class NulloExternalEventProducer : IExternalEventProducer
 {
-    public Task Publish(IExternalEvent @event, CancellationToken ct)
+    public Task Publish(EventEnvelope @event, CancellationToken ct)
     {
         return Task.CompletedTask;
     }

--- a/Core/Events/IExternalEvent.cs
+++ b/Core/Events/IExternalEvent.cs
@@ -1,5 +1,5 @@
 namespace Core.Events;
 
-public interface IExternalEvent: IEvent
+public interface IExternalEvent
 {
 }

--- a/Core/Events/Mediator/IEvent.cs
+++ b/Core/Events/Mediator/IEvent.cs
@@ -1,6 +1,6 @@
 using MediatR;
 
-namespace Core.Events;
+namespace Core.Events.Mediator;
 
 public interface IEvent: INotification
 {

--- a/Core/Events/Mediator/MediatorEventBus.cs
+++ b/Core/Events/Mediator/MediatorEventBus.cs
@@ -1,4 +1,3 @@
-using Core.Events.External;
 using MediatR;
 
 namespace Core.Events.Mediator;
@@ -12,15 +11,12 @@ public interface IEventBus
 public class MediatorEventBus: IEventBus
 {
     private readonly IMediator mediator;
-    private readonly IExternalEventProducer externalEventProducer;
 
     public MediatorEventBus(
-        IMediator mediator,
-        IExternalEventProducer externalEventProducer
+        IMediator mediator
     )
     {
         this.mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
-        this.externalEventProducer = externalEventProducer?? throw new ArgumentNullException(nameof(externalEventProducer));
     }
 
     public async Task Publish(IEvent[] events, CancellationToken ct)
@@ -34,8 +30,5 @@ public class MediatorEventBus: IEventBus
     public async Task Publish(IEvent @event, CancellationToken ct)
     {
         await mediator.Publish(@event, ct);
-
-        if (@event is IExternalEvent externalEvent)
-            await externalEventProducer.Publish(externalEvent, ct);
     }
 }

--- a/EventSourcing.NetCore.sln
+++ b/EventSourcing.NetCore.sln
@@ -40,6 +40,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Workshops", "Workshops", "{CEEE5F74-121E-437F-B3B4-4E7C65482644}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MeetingsManagement", "MeetingsManagement", "{A8E25331-55E9-4D1A-87A4-136EC4D2A4B5}"
+	ProjectSection(SolutionItems) = preProject
+		Sample\MeetingsManagement\Readme.md = Sample\MeetingsManagement\Readme.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docker", "docker", "{E15B4D4B-1527-446F-8613-A09B230D6643}"
 ProjectSection(SolutionItems) = preProject

--- a/Sample/AsyncProjections/SmartHome.Temperature/MotionSensors/InstallingMotionSensor/MotionSensorInstalled.cs
+++ b/Sample/AsyncProjections/SmartHome.Temperature/MotionSensors/InstallingMotionSensor/MotionSensorInstalled.cs
@@ -1,11 +1,9 @@
-using Core.Events;
-
 namespace SmartHome.Temperature.MotionSensors.InstallingMotionSensor;
 
 public record MotionSensorInstalled(
     Guid MotionSensorId,
     DateTime InstalledAt
-) : IEvent
+)
 {
     public static MotionSensorInstalled Create(
         Guid motionSensorId,

--- a/Sample/AsyncProjections/SmartHome.Temperature/TemperatureMeasurements/RecordingTemperature/TemperatureRecorded.cs
+++ b/Sample/AsyncProjections/SmartHome.Temperature/TemperatureMeasurements/RecordingTemperature/TemperatureRecorded.cs
@@ -1,12 +1,10 @@
-using Core.Events;
-
 namespace SmartHome.Temperature.TemperatureMeasurements.RecordingTemperature;
 
 public record TemperatureRecorded(
     Guid MeasurementId,
     decimal Temperature,
     DateTimeOffset MeasuredAt
-): IEvent
+)
 {
     public static TemperatureRecorded Create(Guid measurementId, decimal temperature)
     {

--- a/Sample/AsyncProjections/SmartHome.Temperature/TemperatureMeasurements/StartingTemperatureMeasurement/TemperatureMeasurementStarted.cs
+++ b/Sample/AsyncProjections/SmartHome.Temperature/TemperatureMeasurements/StartingTemperatureMeasurement/TemperatureMeasurementStarted.cs
@@ -1,9 +1,8 @@
-using Core.Events;
 using Newtonsoft.Json;
 
 namespace SmartHome.Temperature.TemperatureMeasurements.StartingTemperatureMeasurement;
 
-public class TemperatureMeasurementStarted : IEvent
+public class TemperatureMeasurementStarted
 {
     public Guid MeasurementId { get; }
     public DateTimeOffset StartedAt { get; }

--- a/Sample/ECommerce/Carts/Carts/ShoppingCarts/AddingProduct/ProductAdded.cs
+++ b/Sample/ECommerce/Carts/Carts/ShoppingCarts/AddingProduct/ProductAdded.cs
@@ -1,12 +1,11 @@
 using Carts.ShoppingCarts.Products;
-using Core.Events;
 
 namespace Carts.ShoppingCarts.AddingProduct;
 
 public record ProductAdded(
     Guid CartId,
     PricedProductItem ProductItem
-): IEvent
+)
 {
     public static ProductAdded Create(Guid cartId, PricedProductItem productItem)
     {

--- a/Sample/ECommerce/Carts/Carts/ShoppingCarts/ConfirmingCart/ShoppingCartConfirmed.cs
+++ b/Sample/ECommerce/Carts/Carts/ShoppingCarts/ConfirmingCart/ShoppingCartConfirmed.cs
@@ -1,11 +1,9 @@
-using Core.Events;
-
 namespace Carts.ShoppingCarts.ConfirmingCart;
 
 public record ShoppingCartConfirmed(
     Guid CartId,
     DateTime ConfirmedAt
-): IEvent
+)
 {
     public static ShoppingCartConfirmed Create(Guid cartId, DateTime confirmedAt)
     {

--- a/Sample/ECommerce/Carts/Carts/ShoppingCarts/InitializingCart/ShoppingCartInitialized.cs
+++ b/Sample/ECommerce/Carts/Carts/ShoppingCarts/InitializingCart/ShoppingCartInitialized.cs
@@ -1,12 +1,10 @@
-using Core.Events;
-
 namespace Carts.ShoppingCarts.InitializingCart;
 
 public record ShoppingCartInitialized(
     Guid CartId,
     Guid ClientId,
     ShoppingCartStatus ShoppingCartStatus
-): IEvent
+)
 {
     public static ShoppingCartInitialized Create(Guid cartId, Guid clientId, ShoppingCartStatus shoppingCartStatus)
     {

--- a/Sample/ECommerce/Carts/Carts/ShoppingCarts/RemovingProduct/ProductRemoved.cs
+++ b/Sample/ECommerce/Carts/Carts/ShoppingCarts/RemovingProduct/ProductRemoved.cs
@@ -1,12 +1,11 @@
 using Carts.ShoppingCarts.Products;
-using Core.Events;
 
 namespace Carts.ShoppingCarts.RemovingProduct;
 
 public record ProductRemoved(
     Guid CartId,
     PricedProductItem ProductItem
-): IEvent
+)
 {
     public static ProductRemoved Create(Guid cartId, PricedProductItem productItem)
     {

--- a/Sample/ECommerce/Orders/Orders/Orders/CancellingOrder/OrderCancelled.cs
+++ b/Sample/ECommerce/Orders/Orders/Orders/CancellingOrder/OrderCancelled.cs
@@ -1,5 +1,3 @@
-using Core.Events;
-
 namespace Orders.Orders.CancellingOrder;
 
 public record OrderCancelled(
@@ -7,7 +5,7 @@ public record OrderCancelled(
     Guid? PaymentId,
     OrderCancellationReason OrderCancellationReason,
     DateTime CancelledAt
-): IEvent
+)
 {
     public static OrderCancelled Create(Guid orderId,
         Guid? paymentId,

--- a/Sample/ECommerce/Orders/Orders/Orders/CompletingOrder/OrderCompleted.cs
+++ b/Sample/ECommerce/Orders/Orders/Orders/CompletingOrder/OrderCompleted.cs
@@ -1,11 +1,9 @@
-using Core.Events;
-
 namespace Orders.Orders.CompletingOrder;
 
 public record OrderCompleted(
     Guid OrderId,
     DateTime CompletedAt
-): IEvent
+)
 {
     public static OrderCompleted Create(Guid orderId, DateTime completedAt)
     {

--- a/Sample/ECommerce/Orders/Orders/Orders/InitializingOrder/OrderInitialized.cs
+++ b/Sample/ECommerce/Orders/Orders/Orders/InitializingOrder/OrderInitialized.cs
@@ -1,4 +1,3 @@
-using Core.Events;
 using Orders.Products;
 
 namespace Orders.Orders.InitializingOrder;
@@ -9,7 +8,7 @@ public record OrderInitialized(
     IReadOnlyList<PricedProductItem> ProductItems,
     decimal TotalPrice,
     DateTime InitializedAt
-): IEvent
+)
 {
     public static OrderInitialized Create(
         Guid orderId,

--- a/Sample/ECommerce/Orders/Orders/Orders/RecordingOrderPayment/OrderPaymentRecorded.cs
+++ b/Sample/ECommerce/Orders/Orders/Orders/RecordingOrderPayment/OrderPaymentRecorded.cs
@@ -1,4 +1,3 @@
-using Core.Events;
 using Orders.Products;
 
 namespace Orders.Orders.RecordingOrderPayment;
@@ -9,7 +8,7 @@ public record OrderPaymentRecorded(
     IReadOnlyList<PricedProductItem> ProductItems,
     decimal Amount,
     DateTime PaymentRecordedAt
-): IEvent
+)
 {
     public static OrderPaymentRecorded Create(
         Guid orderId,

--- a/Sample/ECommerce/Orders/Orders/Shipments/OutOfStockProduct/ProductWasOutOfStock.cs
+++ b/Sample/ECommerce/Orders/Orders/Shipments/OutOfStockProduct/ProductWasOutOfStock.cs
@@ -1,9 +1,8 @@
-using Core.Events;
 using Orders.Products;
 
 namespace Orders.Shipments.OutOfStockProduct;
 
-public class ProductWasOutOfStock: IEvent
+public class ProductWasOutOfStock
 {
     public Guid OrderId { get; }
 

--- a/Sample/ECommerce/Payments/Payments/Payments/CompletingPayment/PaymentCompleted.cs
+++ b/Sample/ECommerce/Payments/Payments/Payments/CompletingPayment/PaymentCompleted.cs
@@ -1,11 +1,9 @@
-using Core.Events;
-
 namespace Payments.Payments.CompletingPayment;
 
 public record PaymentCompleted(
     Guid PaymentId,
     DateTime CompletedAt
-): IEvent
+)
 {
     public static PaymentCompleted Create(Guid paymentId, DateTime completedAt)
     {

--- a/Sample/ECommerce/Payments/Payments/Payments/DiscardingPayment/PaymentDiscarded.cs
+++ b/Sample/ECommerce/Payments/Payments/Payments/DiscardingPayment/PaymentDiscarded.cs
@@ -1,11 +1,9 @@
-using Core.Events;
-
 namespace Payments.Payments.DiscardingPayment;
 
 public record PaymentDiscarded(
     Guid PaymentId,
     DiscardReason DiscardReason,
-    DateTime DiscardedAt): IEvent
+    DateTime DiscardedAt)
 {
     public static PaymentDiscarded Create(Guid paymentId, DiscardReason discardReason, DateTime discardedAt)
     {

--- a/Sample/ECommerce/Payments/Payments/Payments/RequestingPayment/PaymentRequested.cs
+++ b/Sample/ECommerce/Payments/Payments/Payments/RequestingPayment/PaymentRequested.cs
@@ -1,12 +1,10 @@
-using Core.Events;
-
 namespace Payments.Payments.RequestingPayment;
 
 public record PaymentRequested(
     Guid PaymentId,
     Guid OrderId,
     decimal Amount
-): IEvent
+)
 {
     public static PaymentRequested Create(Guid paymentId, Guid orderId, in decimal amount)
     {

--- a/Sample/ECommerce/Payments/Payments/Payments/TimingOutPayment/PaymentTimedOut.cs
+++ b/Sample/ECommerce/Payments/Payments/Payments/TimingOutPayment/PaymentTimedOut.cs
@@ -1,11 +1,9 @@
-using Core.Events;
-
 namespace Payments.Payments.TimingOutPayment;
 
 public record PaymentTimedOut(
     Guid PaymentId,
     DateTime TimedOutAt
-): IEvent
+)
 {
     public static PaymentTimedOut Create(Guid paymentId, in DateTime timedOutAt)
     {

--- a/Sample/ECommerce/Shipments/Shipments/Packages/PackageService.cs
+++ b/Sample/ECommerce/Shipments/Shipments/Packages/PackageService.cs
@@ -1,4 +1,3 @@
-using Core.Events;
 using Microsoft.EntityFrameworkCore;
 using Shipments.Packages.Events.External;
 using Shipments.Packages.Requests;
@@ -92,14 +91,14 @@ internal class PackageService: IPackageService
         await SaveChanges(cancellationToken);
     }
 
-    private async Task SaveChangesAndPublish(IEvent @event, CancellationToken cancellationToken)
+    private async Task SaveChangesAndPublish(object @event, CancellationToken cancellationToken)
     {
         await SaveChanges(cancellationToken);
 
         await Publish(@event, cancellationToken);
     }
 
-    private async Task Publish(IEvent @event, CancellationToken cancellationToken)
+    private async Task Publish(object @event, CancellationToken cancellationToken)
     {
         await eventBus.Publish(@event, cancellationToken);
     }

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts.Tests/Builders/CartBuilder.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts.Tests/Builders/CartBuilder.cs
@@ -1,12 +1,11 @@
 using Carts.ShoppingCarts;
 using Carts.ShoppingCarts.InitializingCart;
-using Core.Events;
 
 namespace Carts.Tests.Builders;
 
 internal class CartBuilder
 {
-    private readonly Queue<IEvent> eventsToApply = new();
+    private readonly Queue<object> eventsToApply = new();
 
     public CartBuilder Initialized()
     {

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/AddingProduct/ProductAdded.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/AddingProduct/ProductAdded.cs
@@ -1,12 +1,11 @@
 using Carts.ShoppingCarts.Products;
-using Core.Events;
 
 namespace Carts.ShoppingCarts.AddingProduct;
 
 public record ProductAdded(
     Guid CartId,
     PricedProductItem ProductItem
-): IEvent
+)
 {
     public static ProductAdded Create(Guid cartId, PricedProductItem productItem)
     {

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/ConfirmingCart/ShoppingCartConfirmed.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/ConfirmingCart/ShoppingCartConfirmed.cs
@@ -1,11 +1,9 @@
-using Core.Events;
-
 namespace Carts.ShoppingCarts.ConfirmingCart;
 
 public record ShoppingCartConfirmed(
     Guid CartId,
     DateTime ConfirmedAt
-): IEvent
+)
 {
     public static ShoppingCartConfirmed Create(Guid cartId, DateTime confirmedAt)
     {

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/InitializingCart/ShoppingCartInitialized.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/InitializingCart/ShoppingCartInitialized.cs
@@ -1,12 +1,10 @@
-using Core.Events;
-
 namespace Carts.ShoppingCarts.InitializingCart;
 
 public record ShoppingCartInitialized(
     Guid CartId,
     Guid ClientId,
     ShoppingCartStatus ShoppingCartStatus
-): IEvent
+)
 {
     public static ShoppingCartInitialized Create(Guid cartId, Guid clientId, ShoppingCartStatus shoppingCartStatus)
     {

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/RemovingProduct/ProductRemoved.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/RemovingProduct/ProductRemoved.cs
@@ -1,12 +1,11 @@
 using Carts.ShoppingCarts.Products;
-using Core.Events;
 
 namespace Carts.ShoppingCarts.RemovingProduct;
 
 public record ProductRemoved(
     Guid CartId,
     PricedProductItem ProductItem
-): IEvent
+)
 {
     public static ProductRemoved Create(Guid cartId, PricedProductItem productItem)
     {

--- a/Sample/MeetingsManagement/MeetingsManagement/Meetings/SchedulingMeeting/MeetingScheduled.cs
+++ b/Sample/MeetingsManagement/MeetingsManagement/Meetings/SchedulingMeeting/MeetingScheduled.cs
@@ -1,4 +1,3 @@
-using Core.Events;
 using MeetingsManagement.Meetings.ValueObjects;
 
 namespace MeetingsManagement.Meetings.SchedulingMeeting;
@@ -6,7 +5,7 @@ namespace MeetingsManagement.Meetings.SchedulingMeeting;
 public record MeetingScheduled(
     Guid MeetingId,
     DateRange Occurs
-): IEvent
+)
 {
     public static MeetingScheduled Create(Guid meetingId, DateRange occurs)
     {

--- a/Sample/MeetingsManagement/MeetingsSearch.IntegrationTests/Meetings/CreatingMeeting/CreateMeetingTests.cs
+++ b/Sample/MeetingsManagement/MeetingsSearch.IntegrationTests/Meetings/CreatingMeeting/CreateMeetingTests.cs
@@ -1,4 +1,5 @@
 using Core.Api.Testing;
+using Core.Events;
 using Core.Testing;
 using FluentAssertions;
 using MeetingsSearch.Api;
@@ -18,9 +19,12 @@ public class CreateMeetingFixture: ApiWithEventsFixture<Startup>
     public override async Task InitializeAsync()
     {
         // prepare event
-        var @event = new MeetingCreated(
-            MeetingId,
-            MeetingName
+        var @event = new EventEnvelope<MeetingCreated>(
+            new MeetingCreated(
+                MeetingId,
+                MeetingName
+            ),
+            new EventMetadata("event-id", 1, 2, null)
         );
 
         // send meeting created event to internal event bus

--- a/Sample/MeetingsManagement/MeetingsSearch/Meetings/CreatingMeeting/MeetingCreated.cs
+++ b/Sample/MeetingsManagement/MeetingsSearch/Meetings/CreatingMeeting/MeetingCreated.cs
@@ -3,7 +3,7 @@ using Core.Events;
 
 namespace MeetingsSearch.Meetings.CreatingMeeting;
 
-internal class MeetingCreated: IEvent
+internal class MeetingCreated
 {
     public Guid MeetingId { get; }
     public string Name { get; }

--- a/Sample/Tickets/Tickets.Tests/Extensions/AggregateExtensions.cs
+++ b/Sample/Tickets/Tickets.Tests/Extensions/AggregateExtensions.cs
@@ -5,7 +5,7 @@ namespace Tickets.Tests.Extensions;
 
 public static class AggregateExtensions
 {
-    public static T? PublishedEvent<T>(this IAggregate aggregate) where T : class, IEvent
+    public static T? PublishedEvent<T>(this IAggregate aggregate) where T : class
     {
         return aggregate.DequeueUncommittedEvents().LastOrDefault() as T;
     }

--- a/Sample/Tickets/Tickets/Reservations/CancellingReservation/ReservationCancelled.cs
+++ b/Sample/Tickets/Tickets/Reservations/CancellingReservation/ReservationCancelled.cs
@@ -1,7 +1,5 @@
-using Core.Events;
-
 namespace Tickets.Reservations.CancellingReservation;
 
 public record ReservationCancelled(
     Guid ReservationId
-): IEvent;
+);

--- a/Sample/Tickets/Tickets/Reservations/ChangingReservationSeat/ReservationSeatChanged.cs
+++ b/Sample/Tickets/Tickets/Reservations/ChangingReservationSeat/ReservationSeatChanged.cs
@@ -1,8 +1,6 @@
-using Core.Events;
-
 namespace Tickets.Reservations.ChangingReservationSeat;
 
 public record ReservationSeatChanged(
     Guid ReservationId,
     Guid SeatId
-): IEvent;
+);

--- a/Sample/Tickets/Tickets/Reservations/ConfirmingReservation/ReservationConfirmed.cs
+++ b/Sample/Tickets/Tickets/Reservations/ConfirmingReservation/ReservationConfirmed.cs
@@ -1,7 +1,5 @@
-using Core.Events;
-
 namespace Tickets.Reservations.ConfirmingReservation;
 
 public record ReservationConfirmed(
     Guid ReservationId
-): IEvent;
+);

--- a/Sample/Tickets/Tickets/Reservations/CreatingTentativeReservation/TentativeReservationCreated.cs
+++ b/Sample/Tickets/Tickets/Reservations/CreatingTentativeReservation/TentativeReservationCreated.cs
@@ -1,12 +1,10 @@
-using Core.Events;
-
 namespace Tickets.Reservations.CreatingTentativeReservation;
 
 public record TentativeReservationCreated(
     Guid ReservationId,
     Guid SeatId,
     string Number
-): IEvent
+)
 {
     public static TentativeReservationCreated Create(Guid reservationId, Guid seatId, string number)
     {


### PR DESCRIPTION
Thanks to that, Kafka Producer can also include it, and KafkaConsumer can get them and republish, maintaining CorrelationId and generating new CausationId.

Removed usages of `IEvent`. The marker interface is no longer needed as the `MediatR` event bus is not used in samples.

**Note:** It seems that `KafkaProducer` is having a hard time locally locking itself while publishing events. I will tackle this issue in a follow-up PR.