### PR TITLE
Fixed Optimistic Concurrency in ESDB Samples

### DIFF
--- a/Sample/EventStoreDB/ECommerce/Carts/Carts.Tests/Carts/ConfirmingCart/ConfirmCartTests.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts.Tests/Carts/ConfirmingCart/ConfirmCartTests.cs
@@ -23,7 +23,7 @@ public class ConfirmCartTests
 
         // Then
         cart.Status.Should().Be(ShoppingCartStatus.Confirmed);
-        cart.Version.Should().Be(2);
+        cart.Version.Should().Be(1);
 
         var @event = cart.PublishedEvent<ShoppingCartConfirmed>();
 

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts.Tests/Extensions/Reservations/CartExtensions.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts.Tests/Extensions/Reservations/CartExtensions.cs
@@ -18,7 +18,7 @@ internal static class CartExtensions
         shoppingCart.Status.Should().Be(ShoppingCartStatus.Pending);
         shoppingCart.ProductItems.Should().BeEmpty();
         shoppingCart.TotalPrice.Should().Be(0);
-        shoppingCart.Version.Should().Be(1);
+        shoppingCart.Version.Should().Be(0);
 
         return shoppingCart;
     }

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/ShoppingCart.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts/ShoppingCarts/ShoppingCart.cs
@@ -63,7 +63,7 @@ public class ShoppingCart: Aggregate
 
     private void Apply(ShoppingCartInitialized @event)
     {
-        Version++;
+        Version = 0;
 
         Id = @event.CartId;
         ClientId = @event.ClientId;


### PR DESCRIPTION
- for the case where no expected version was supplied, wrong version was used. ESDB has first revision set 0, and expects the revision of the stream before update. Fixed by sending an initial aggregate version at load,
- fixed setting the Cart aggregate version for Initialized event (should be 0 instead of 1),
- fixed dependencies scoping for the functions registration in Simple ESDB sample.