### PR TITLE
Updates to projections tests in Introduction to Event Sourcing workshop

### DIFF
--- a/Workshops/IntroductionToEventSourcing/12-Projections/ProjectionsTests.cs
+++ b/Workshops/IntroductionToEventSourcing/12-Projections/ProjectionsTests.cs
@@ -148,8 +148,11 @@ public class ProjectionsTests
         var database = new Database();
 
         // TODO:
-        // 1. Register here your event handlers using `eventBus.Register`.
-        // 2. Store results in database.
+        // 1. Register here your event handlers using `eventBus.Register`, e.g.
+        eventBus.Register((EventEnvelope<ShoppingCartOpened> @event) =>
+        {
+            // 2. Store results in database.
+        });
 
         eventBus.Publish(events);
 
@@ -180,7 +183,7 @@ public class ProjectionsTests
         shoppingCart = database.Get<ShoppingCartDetails>(otherClientShoppingCartId)!;
 
         shoppingCart.Should().NotBeNull();
-        shoppingCart.Id.Should().Be(cancelledShoppingCartId);
+        shoppingCart.Id.Should().Be(otherClientShoppingCartId);
         shoppingCart.ClientId.Should().Be(otherClientId);
         shoppingCart.ProductItems.Should().HaveCount(1);
         shoppingCart.Status.Should().Be(ShoppingCartStatus.Confirmed);
@@ -199,16 +202,16 @@ public class ProjectionsTests
         shoppingCart.ProductItems[0].Should().Be(trousers);
 
         // first pending
-        shoppingCart = database.Get<ShoppingCartDetails>(otherConfirmedShoppingCartId)!;
+        shoppingCart = database.Get<ShoppingCartDetails>(otherPendingShoppingCartId)!;
 
         shoppingCart.Should().NotBeNull();
-        shoppingCart.Id.Should().Be(otherConfirmedShoppingCartId);
+        shoppingCart.Id.Should().Be(otherPendingShoppingCartId);
         shoppingCart.ClientId.Should().Be(clientId);
         shoppingCart.ProductItems.Should().BeEmpty();
         shoppingCart.Status.Should().Be(ShoppingCartStatus.Pending);
 
         // summary
-        var summary = database.Get<ShoppingCartsClientSummary>(cancelledShoppingCartId)!;
+        var summary = database.Get<ShoppingCartsClientSummary>(clientId)!;
         summary.Id.Should().Be(clientId);
         summary.TotalItemsCount.Should().Be(3);
         summary.TotalAmount.Should().Be(pairOfShoes.TotalAmount + tShirt.TotalAmount + trousers.TotalAmount);

--- a/Workshops/IntroductionToEventSourcing/12-Projections/Tools/Database.cs
+++ b/Workshops/IntroductionToEventSourcing/12-Projections/Tools/Database.cs
@@ -6,7 +6,10 @@ public class Database
 
     public void Store<T>(Guid id, T obj) where T: class
     {
-        storage.Add(id, obj);
+        if (!storage.ContainsKey(id))
+            storage.Add(id, obj);
+        else
+            storage[id] = obj;
     }
 
     public T? Get<T>(Guid id) where T: class

--- a/Workshops/IntroductionToEventSourcing/13-Projections.Idempotency/ProjectionsTests.cs
+++ b/Workshops/IntroductionToEventSourcing/13-Projections.Idempotency/ProjectionsTests.cs
@@ -147,9 +147,14 @@ public class ProjectionsTests
         var eventBus = new EventBus();
         var database = new Database();
 
+
         // TODO:
-        // 1. Register here your event handlers using `eventBus.Register`.
-        // 2. Store results in database.
+        // 1. Register here your event handlers using `eventBus.Register`, e.g.
+        eventBus.Register((EventEnvelope<ShoppingCartOpened> @event) =>
+        {
+            // 2. Store results in database.
+        });
+
 
         eventBus.Publish(events);
 
@@ -180,7 +185,7 @@ public class ProjectionsTests
         shoppingCart = database.Get<ShoppingCartDetails>(otherClientShoppingCartId)!;
 
         shoppingCart.Should().NotBeNull();
-        shoppingCart.Id.Should().Be(cancelledShoppingCartId);
+        shoppingCart.Id.Should().Be(otherClientShoppingCartId);
         shoppingCart.ClientId.Should().Be(otherClientId);
         shoppingCart.ProductItems.Should().HaveCount(1);
         shoppingCart.Status.Should().Be(ShoppingCartStatus.Confirmed);
@@ -199,16 +204,16 @@ public class ProjectionsTests
         shoppingCart.ProductItems[0].Should().Be(trousers);
 
         // first pending
-        shoppingCart = database.Get<ShoppingCartDetails>(otherConfirmedShoppingCartId)!;
+        shoppingCart = database.Get<ShoppingCartDetails>(otherPendingShoppingCartId)!;
 
         shoppingCart.Should().NotBeNull();
-        shoppingCart.Id.Should().Be(otherConfirmedShoppingCartId);
+        shoppingCart.Id.Should().Be(otherPendingShoppingCartId);
         shoppingCart.ClientId.Should().Be(clientId);
         shoppingCart.ProductItems.Should().BeEmpty();
         shoppingCart.Status.Should().Be(ShoppingCartStatus.Pending);
 
         // summary
-        var summary = database.Get<ShoppingCartsClientSummary>(cancelledShoppingCartId)!;
+        var summary = database.Get<ShoppingCartsClientSummary>(clientId)!;
         summary.Id.Should().Be(clientId);
         summary.TotalItemsCount.Should().Be(3);
         summary.TotalAmount.Should().Be(pairOfShoes.TotalAmount + tShirt.TotalAmount + trousers.TotalAmount);

--- a/Workshops/IntroductionToEventSourcing/13-Projections.Idempotency/Tools/Database.cs
+++ b/Workshops/IntroductionToEventSourcing/13-Projections.Idempotency/Tools/Database.cs
@@ -6,7 +6,10 @@ public class Database
 
     public void Store<T>(Guid id, T obj) where T: class
     {
-        storage.Add(id, obj);
+        if (!storage.ContainsKey(id))
+            storage.Add(id, obj);
+        else
+            storage[id] = obj;
     }
 
     public T? Get<T>(Guid id) where T: class

--- a/Workshops/IntroductionToEventSourcing/14-Projections.EventualConsistency/ProjectionsTests.cs
+++ b/Workshops/IntroductionToEventSourcing/14-Projections.EventualConsistency/ProjectionsTests.cs
@@ -148,8 +148,11 @@ public class ProjectionsTests
         var database = new Database();
 
         // TODO:
-        // 1. Register here your event handlers using `eventBus.Register`.
-        // 2. Store results in database.
+        // 1. Register here your event handlers using `eventBus.Register`, e.g.
+        eventBus.Register((EventEnvelope<ShoppingCartOpened> @event) =>
+        {
+            // 2. Store results in database.
+        });
 
         eventBus.Publish(events);
 
@@ -180,7 +183,7 @@ public class ProjectionsTests
         shoppingCart = database.Get<ShoppingCartDetails>(otherClientShoppingCartId)!;
 
         shoppingCart.Should().NotBeNull();
-        shoppingCart.Id.Should().Be(cancelledShoppingCartId);
+        shoppingCart.Id.Should().Be(otherClientShoppingCartId);
         shoppingCart.ClientId.Should().Be(otherClientId);
         shoppingCart.ProductItems.Should().HaveCount(1);
         shoppingCart.Status.Should().Be(ShoppingCartStatus.Confirmed);
@@ -199,16 +202,16 @@ public class ProjectionsTests
         shoppingCart.ProductItems[0].Should().Be(trousers);
 
         // first pending
-        shoppingCart = database.Get<ShoppingCartDetails>(otherConfirmedShoppingCartId)!;
+        shoppingCart = database.Get<ShoppingCartDetails>(otherPendingShoppingCartId)!;
 
         shoppingCart.Should().NotBeNull();
-        shoppingCart.Id.Should().Be(otherConfirmedShoppingCartId);
+        shoppingCart.Id.Should().Be(otherPendingShoppingCartId);
         shoppingCart.ClientId.Should().Be(clientId);
         shoppingCart.ProductItems.Should().BeEmpty();
         shoppingCart.Status.Should().Be(ShoppingCartStatus.Pending);
 
         // summary
-        var summary = database.Get<ShoppingCartsClientSummary>(cancelledShoppingCartId)!;
+        var summary = database.Get<ShoppingCartsClientSummary>(clientId)!;
         summary.Id.Should().Be(clientId);
         summary.TotalItemsCount.Should().Be(3);
         summary.TotalAmount.Should().Be(pairOfShoes.TotalAmount + tShirt.TotalAmount + trousers.TotalAmount);

--- a/Workshops/IntroductionToEventSourcing/14-Projections.EventualConsistency/Tools/Database.cs
+++ b/Workshops/IntroductionToEventSourcing/14-Projections.EventualConsistency/Tools/Database.cs
@@ -12,6 +12,12 @@ public class Database
         var validFrom = DateTime.UtcNow.AddMilliseconds(random.Next(250, 1000));
 
         storage.Add(id, new DataWrapper(obj, validFrom));
+
+
+        if (!storage.ContainsKey(id))
+            storage.Add(id, new DataWrapper(obj, validFrom));
+        else
+            storage[id] = new DataWrapper(obj, validFrom);
     }
 
     public T? Get<T>(Guid id) where T : class


### PR DESCRIPTION
1. Fixed `Database.Store` method to do upsert instead of add.
2. Added hint on how to register an event handler.
3. Fixed copy/paste issues in projections tests