### PR TITLE
Fix broken Elastic Search link

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ docker-compose up
 2. [EventStoreDB](https://eventstore.com) - Event Store 
 3. [MediatR](https://github.com/jbogard/MediatR) - Internal In-Memory Message Bus (for processing Commands, Queries, Events)
 4. [Kafka](https://github.com/jbogard/MediatR) - External Durable Message Bus to integrate services
-5. [ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/elasticsearch-net-getting-started.html) - Read Models
+5. [ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/nest-getting-started.html) - Read Models
 
 ## 6. Samples
 


### PR DESCRIPTION
The current Elastic Search link returns a 404.