### PR TITLE
Brought back publishing externally only events marked as IExternalEvent interface

### DIFF
--- a/Core/Events/External/IExternaEventProducer.cs
+++ b/Core/Events/External/IExternaEventProducer.cs
@@ -24,6 +24,9 @@ public class EventBusDecoratorWithExternalProducer: IEventBus
     {
         await eventBus.Publish(eventEnvelope, ct);
 
-        await externalEventProducer.Publish(eventEnvelope, ct);
+        if (eventEnvelope.Data is IExternalEvent)
+        {
+            await externalEventProducer.Publish(eventEnvelope, ct);
+        }
     }
 }


### PR DESCRIPTION
Brought back publishing externally only events marked as `IExternalEvent` interface that was accidentally removed in https://github.com/oskardudycz/EventSourcing.NetCore/pull/150/files#diff-7bcf4d5fec16e94d333719daa573e42b1826b946dcd21327672c3ca31d1e31f6L27