### PR TITLE
Updated Marten to 5.5.0

### DIFF
--- a/CQRS.Tests/CQRS.Tests.csproj
+++ b/CQRS.Tests/CQRS.Tests.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Core.Api.Testing/Core.Api.Testing.csproj
+++ b/Core.Api.Testing/Core.Api.Testing.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.5" />
     </ItemGroup>
 

--- a/Core.ElasticSearch/Core.ElasticSearch.csproj
+++ b/Core.ElasticSearch/Core.ElasticSearch.csproj
@@ -6,7 +6,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="NEST" Version="7.17.1" />
+        <PackageReference Include="NEST" Version="7.17.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Core.EventStoreDB.Tests/Core.EventStoreDB.Tests.csproj
+++ b/Core.EventStoreDB.Tests/Core.EventStoreDB.Tests.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Core.Kafka.Tests/Core.Kafka.Tests.csproj
+++ b/Core.Kafka.Tests/Core.Kafka.Tests.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Core.Marten/Core.Marten.csproj
+++ b/Core.Marten/Core.Marten.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/Core.Marten/Repository/MartenRepository.cs
+++ b/Core.Marten/Repository/MartenRepository.cs
@@ -8,8 +8,12 @@ public interface IMartenRepository<T> where T : class, IAggregate
 {
     Task<T?> Find(Guid id, CancellationToken cancellationToken);
     Task<long> Add(T aggregate, TraceMetadata? eventMetadata = null, CancellationToken cancellationToken = default);
-    Task<long> Update(T aggregate, long? expectedVersion = null, TraceMetadata? traceMetadata = null, CancellationToken cancellationToken = default);
-    Task<long> Delete(T aggregate, long? expectedVersion = null, TraceMetadata? eventMetadata = null, CancellationToken cancellationToken = default);
+
+    Task<long> Update(T aggregate, long? expectedVersion = null, TraceMetadata? traceMetadata = null,
+        CancellationToken cancellationToken = default);
+
+    Task<long> Delete(T aggregate, long? expectedVersion = null, TraceMetadata? eventMetadata = null,
+        CancellationToken cancellationToken = default);
 }
 
 public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggregate
@@ -26,7 +30,8 @@ public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggrega
     public Task<T?> Find(Guid id, CancellationToken cancellationToken) =>
         documentSession.Events.AggregateStreamAsync<T>(id, token: cancellationToken);
 
-    public async Task<long> Add(T aggregate, TraceMetadata? traceMetadata = null, CancellationToken cancellationToken = default)
+    public async Task<long> Add(T aggregate, TraceMetadata? traceMetadata = null,
+        CancellationToken cancellationToken = default)
     {
         documentSession.CorrelationId = traceMetadata?.CorrelationId?.Value;
         documentSession.CausationId = traceMetadata?.CausationId?.Value;
@@ -43,20 +48,19 @@ public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggrega
         return events.Length;
     }
 
-    public async Task<long> Update(T aggregate, long? expectedVersion = null, TraceMetadata? traceMetadata = null, CancellationToken cancellationToken = default)
+    public async Task<long> Update(T aggregate, long? expectedVersion = null, TraceMetadata? traceMetadata = null,
+        CancellationToken cancellationToken = default)
     {
         documentSession.CorrelationId = traceMetadata?.CorrelationId?.Value;
         documentSession.CausationId = traceMetadata?.CausationId?.Value;
 
         var events = aggregate.DequeueUncommittedEvents();
 
-        var nextVersion = expectedVersion.HasValue ?
-            expectedVersion.Value + events.Length
-            : aggregate.Version;
+        var nextVersion = (expectedVersion ?? aggregate.Version) + events.Length;
 
         documentSession.Events.Append(
             aggregate.Id,
-            aggregate.Version,
+            nextVersion,
             events
         );
 
@@ -65,6 +69,7 @@ public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggrega
         return nextVersion;
     }
 
-    public Task<long> Delete(T aggregate, long? expectedVersion = null, TraceMetadata? traceMetadata = null, CancellationToken cancellationToken = default) =>
+    public Task<long> Delete(T aggregate, long? expectedVersion = null, TraceMetadata? traceMetadata = null,
+        CancellationToken cancellationToken = default) =>
         Update(aggregate, expectedVersion, traceMetadata, cancellationToken);
 }

--- a/Core.Testing/Core.Testing.csproj
+++ b/Core.Testing/Core.Testing.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.5" />
     </ItemGroup>
 

--- a/Core.Tests/Core.Tests.csproj
+++ b/Core.Tests/Core.Tests.csproj
@@ -15,8 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/EventSourcing.Integration.Tests/EventSourcing.Integration.Tests.csproj
+++ b/EventSourcing.Integration.Tests/EventSourcing.Integration.Tests.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Marten.Integration.Tests/CompositeIds/CompositeIdsTests.cs
+++ b/Marten.Integration.Tests/CompositeIds/CompositeIdsTests.cs
@@ -224,25 +224,21 @@ public class Reservation : Aggregate<ReservationId, Guid>
         CustomerId = @event.CustomerId;
         Number = @event.Number;
         Status = ReservationStatus.Tentative;
-        Version++;
     }
 
     public void Apply(ReservationSeatChanged @event)
     {
         SeatId = @event.SeatId;
-        Version++;
     }
 
     public void Apply(ReservationConfirmed @event)
     {
         Status = ReservationStatus.Confirmed;
-        Version++;
     }
 
     public void Apply(ReservationCancelled @event)
     {
         Status = ReservationStatus.Cancelled;
-        Version++;
     }
 }
 

--- a/Marten.Integration.Tests/EventStore/Projections/AggregationProjectionsTest.cs
+++ b/Marten.Integration.Tests/EventStore/Projections/AggregationProjectionsTest.cs
@@ -57,7 +57,7 @@ public class AggregationProjectionsTest: MartenTest
         }
     }
 
-    public class IssueDescriptionsProjection: AggregateProjection<IssueDescriptions>
+    public class IssueDescriptionsProjection: SingleStreamAggregation<IssueDescriptions>
     {
         public void Apply(IssueCreated @event, IssueDescriptions item)
         {

--- a/Marten.Integration.Tests/Marten.Integration.Tests.csproj
+++ b/Marten.Integration.Tests/Marten.Integration.Tests.csproj
@@ -15,8 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/MediatR.Tests/MediatR.Tests.csproj
+++ b/MediatR.Tests/MediatR.Tests.csproj
@@ -14,8 +14,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Sample/ECommerce/Carts/Carts.Api.Tests/Carts.Api.Tests.csproj
+++ b/Sample/ECommerce/Carts/Carts.Api.Tests/Carts.Api.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/Sample/ECommerce/Carts/Carts.Tests/Carts.Tests.csproj
+++ b/Sample/ECommerce/Carts/Carts.Tests/Carts.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Sample/ECommerce/Carts/Carts.Tests/Carts/ConfirmingCart/ConfirmCartTests.cs
+++ b/Sample/ECommerce/Carts/Carts.Tests/Carts/ConfirmingCart/ConfirmCartTests.cs
@@ -23,7 +23,6 @@ public class ConfirmCartTests
 
         // Then
         cart.Status.Should().Be(ShoppingCartStatus.Confirmed);
-        cart.Version.Should().Be(2);
 
         var @event = cart.PublishedEvent<ShoppingCartConfirmed>();
 

--- a/Sample/ECommerce/Carts/Carts.Tests/Extensions/Reservations/CartExtensions.cs
+++ b/Sample/ECommerce/Carts/Carts.Tests/Extensions/Reservations/CartExtensions.cs
@@ -18,7 +18,6 @@ internal static class CartExtensions
         shoppingCart.Status.Should().Be(ShoppingCartStatus.Pending);
         shoppingCart.ProductItems.Should().BeEmpty();
         shoppingCart.TotalPrice.Should().Be(0);
-        shoppingCart.Version.Should().Be(1);
 
         return shoppingCart;
     }

--- a/Sample/ECommerce/Carts/Carts/ShoppingCarts/GettingCartById/ShoppingCartDetails.cs
+++ b/Sample/ECommerce/Carts/Carts/ShoppingCarts/GettingCartById/ShoppingCartDetails.cs
@@ -96,7 +96,7 @@ public class ShoppingCartDetails
     }
 }
 
-public class CartDetailsProjection : AggregateProjection<ShoppingCartDetails>
+public class CartDetailsProjection : SingleStreamAggregation<ShoppingCartDetails>
 {
     public CartDetailsProjection()
     {

--- a/Sample/ECommerce/Carts/Carts/ShoppingCarts/GettingCartById/ShoppingCartDetails.cs
+++ b/Sample/ECommerce/Carts/Carts/ShoppingCarts/GettingCartById/ShoppingCartDetails.cs
@@ -24,8 +24,6 @@ public class ShoppingCartDetails
 
     public void Apply(ShoppingCartOpened @event)
     {
-        Version++;
-
         Id = @event.CartId;
         ClientId = @event.ClientId;
         ProductItems = new List<PricedProductItem>();
@@ -34,8 +32,6 @@ public class ShoppingCartDetails
 
     public void Apply(ProductAdded @event)
     {
-        Version++;
-
         var newProductItem = @event.ProductItem;
 
         var existingProductItem = FindProductItemMatchingWith(newProductItem);
@@ -54,8 +50,6 @@ public class ShoppingCartDetails
 
     public void Apply(ProductRemoved @event)
     {
-        Version++;
-
         var productItemToBeRemoved = @event.ProductItem;
 
         var existingProductItem = FindProductItemMatchingWith(@event.ProductItem);
@@ -77,15 +71,11 @@ public class ShoppingCartDetails
 
     public void Apply(ShoppingCartConfirmed @event)
     {
-        Version++;
-
         Status = ShoppingCartStatus.Confirmed;
     }
 
     public void Apply(ShoppingCartCanceled @event)
     {
-        Version++;
-
         Status = ShoppingCartStatus.Canceled;
     }
 

--- a/Sample/ECommerce/Carts/Carts/ShoppingCarts/GettingCarts/ShoppingCartShortInfo.cs
+++ b/Sample/ECommerce/Carts/Carts/ShoppingCarts/GettingCarts/ShoppingCartShortInfo.cs
@@ -43,7 +43,7 @@ public class ShoppingCartShortInfo
     }
 }
 
-public class CartShortInfoProjection : AggregateProjection<ShoppingCartShortInfo>
+public class CartShortInfoProjection : SingleStreamAggregation<ShoppingCartShortInfo>
 {
     public CartShortInfoProjection()
     {

--- a/Sample/ECommerce/Carts/Carts/ShoppingCarts/ShoppingCart.cs
+++ b/Sample/ECommerce/Carts/Carts/ShoppingCarts/ShoppingCart.cs
@@ -44,8 +44,6 @@ public class ShoppingCart: Aggregate
 
     public void Apply(ShoppingCartOpened @event)
     {
-        Version++;
-
         Id = @event.CartId;
         ClientId = @event.ClientId;
         ProductItems = new List<PricedProductItem>();
@@ -69,8 +67,6 @@ public class ShoppingCart: Aggregate
 
     public void Apply(ProductAdded @event)
     {
-        Version++;
-
         var newProductItem = @event.ProductItem;
 
         var existingProductItem = FindProductItemMatchingWith(newProductItem);
@@ -109,8 +105,6 @@ public class ShoppingCart: Aggregate
 
     public void Apply(ProductRemoved @event)
     {
-        Version++;
-
         var productItemToBeRemoved = @event.ProductItem;
 
         var existingProductItem = FindProductItemMatchingWith(@event.ProductItem);
@@ -143,8 +137,6 @@ public class ShoppingCart: Aggregate
 
     public void Apply(ShoppingCartConfirmed @event)
     {
-        Version++;
-
         Status = ShoppingCartStatus.Confirmed;
     }
 
@@ -161,8 +153,6 @@ public class ShoppingCart: Aggregate
 
     public void Apply(ShoppingCartCanceled @event)
     {
-        Version++;
-
         Status = ShoppingCartStatus.Canceled;
     }
 

--- a/Sample/ECommerce/Orders/Orders.Api.Tests/Orders.Api.Tests.csproj
+++ b/Sample/ECommerce/Orders/Orders.Api.Tests/Orders.Api.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/Sample/ECommerce/Orders/Orders.Tests/Orders.Tests.csproj
+++ b/Sample/ECommerce/Orders/Orders.Tests/Orders.Tests.csproj
@@ -6,7 +6,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Sample/ECommerce/Orders/Orders/Orders/Order.cs
+++ b/Sample/ECommerce/Orders/Orders/Orders/Order.cs
@@ -51,8 +51,6 @@ public class Order: Aggregate
 
     public void Apply(OrderInitialized @event)
     {
-        Version++;
-
         Id = @event.OrderId;
         ClientId = @event.ClientId;
         ProductItems = @event.ProductItems;
@@ -75,8 +73,6 @@ public class Order: Aggregate
 
     public void Apply(OrderPaymentRecorded @event)
     {
-        Version++;
-
         PaymentId = @event.PaymentId;
         Status = OrderStatus.Paid;
     }
@@ -94,8 +90,6 @@ public class Order: Aggregate
 
     public void Apply(OrderCompleted @event)
     {
-        Version++;
-
         Status = OrderStatus.Completed;
     }
 
@@ -112,8 +106,6 @@ public class Order: Aggregate
 
     public void Apply(OrderCancelled @event)
     {
-        Version++;
-
         Status = OrderStatus.Cancelled;
     }
 }

--- a/Sample/ECommerce/Payments/Payments.Api.Tests/Payments.Api.Tests.csproj
+++ b/Sample/ECommerce/Payments/Payments.Api.Tests/Payments.Api.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/Sample/ECommerce/Payments/Payments.Tests/Payments.Tests.csproj
+++ b/Sample/ECommerce/Payments/Payments.Tests/Payments.Tests.csproj
@@ -6,7 +6,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Sample/ECommerce/Payments/Payments/Payments/Payment.cs
+++ b/Sample/ECommerce/Payments/Payments/Payments/Payment.cs
@@ -31,8 +31,6 @@ public class Payment: Aggregate
 
     public void Apply(PaymentRequested @event)
     {
-        Version++;
-
         Id = @event.PaymentId;
         OrderId = @event.OrderId;
         Amount = @event.Amount;
@@ -51,8 +49,6 @@ public class Payment: Aggregate
 
     public void Apply(PaymentCompleted @event)
     {
-        Version++;
-
         Status = PaymentStatus.Completed;
     }
 
@@ -69,8 +65,6 @@ public class Payment: Aggregate
 
     public void Apply(PaymentDiscarded @event)
     {
-        Version++;
-
         Status = PaymentStatus.Failed;
     }
 
@@ -87,8 +81,6 @@ public class Payment: Aggregate
 
     public void Apply(PaymentTimedOut @event)
     {
-        Version++;
-
         Status = PaymentStatus.Failed;
     }
 }

--- a/Sample/ECommerce/Shipments/Shipments.Api.Tests/Shipments.Api.Tests.csproj
+++ b/Sample/ECommerce/Shipments/Shipments.Api.Tests/Shipments.Api.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/Sample/ECommerce/Shipments/Shipments.Tests/Shipments.Tests.csproj
+++ b/Sample/ECommerce/Shipments/Shipments.Tests/Shipments.Tests.csproj
@@ -6,7 +6,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Sample/EventPipelines/EventPipelines.Tests/EventPipelines.Tests.csproj
+++ b/Sample/EventPipelines/EventPipelines.Tests/EventPipelines.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts.Api.Tests/Carts.Api.Tests.csproj
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts.Api.Tests/Carts.Api.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts.Tests/Carts.Tests.csproj
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts.Tests/Carts.Tests.csproj
@@ -6,7 +6,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Sample/EventStoreDB/Simple/ECommerce.Api.Tests/ECommerce.Api.Tests.csproj
+++ b/Sample/EventStoreDB/Simple/ECommerce.Api.Tests/ECommerce.Api.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Sample/EventsVersioning/EventsVersioning.Tests/EventsVersioning.Tests.csproj
+++ b/Sample/EventsVersioning/EventsVersioning.Tests/EventsVersioning.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Sample/MeetingsManagement/MeetingsManagement.Api/MeetingsManagement.Api.csproj
+++ b/Sample/MeetingsManagement/MeetingsManagement.Api/MeetingsManagement.Api.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.5" />

--- a/Sample/MeetingsManagement/MeetingsManagement.IntegrationTests/MeetingsManagement.IntegrationTests.csproj
+++ b/Sample/MeetingsManagement/MeetingsManagement.IntegrationTests/MeetingsManagement.IntegrationTests.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Sample/MeetingsManagement/MeetingsManagement/Meetings/GettingMeeting/MeetingView.cs
+++ b/Sample/MeetingsManagement/MeetingsManagement/Meetings/GettingMeeting/MeetingView.cs
@@ -17,7 +17,7 @@ public class MeetingView
     public DateTime? End { get; set; }
 }
 
-public class MeetingViewProjection: AggregateProjection<MeetingView>
+public class MeetingViewProjection: SingleStreamAggregation<MeetingView>
 {
     public void Apply(MeetingCreated @event, MeetingView view)
     {

--- a/Sample/MeetingsManagement/MeetingsManagement/Meetings/Meeting.cs
+++ b/Sample/MeetingsManagement/MeetingsManagement/Meetings/Meeting.cs
@@ -41,8 +41,6 @@ public class Meeting: Aggregate
         Id = @event.MeetingId;
         Name = @event.Name;
         Created = @event.Created;
-
-        Version++;
     }
 
     internal void Schedule(DateRange occurs)
@@ -56,7 +54,5 @@ public class Meeting: Aggregate
     public void Apply(MeetingScheduled @event)
     {
         Occurs = @event.Occurs;
-
-        Version++;
     }
 }

--- a/Sample/MeetingsManagement/MeetingsManagement/MeetingsManagement.csproj
+++ b/Sample/MeetingsManagement/MeetingsManagement/MeetingsManagement.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="JsonNet.PrivateSettersContractResolvers" Version="1.0.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/Sample/MeetingsManagement/MeetingsSearch.IntegrationTests/MeetingsSearch.IntegrationTests.csproj
+++ b/Sample/MeetingsManagement/MeetingsSearch.IntegrationTests/MeetingsSearch.IntegrationTests.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Sample/MeetingsManagement/MeetingsSearch/MeetingsSearch.csproj
+++ b/Sample/MeetingsManagement/MeetingsSearch/MeetingsSearch.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NEST" Version="7.17.1" />
+        <PackageReference Include="NEST" Version="7.17.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Sample/Tickets/Tickets.Api.Tests/Tickets.Api.Tests.csproj
+++ b/Sample/Tickets/Tickets.Api.Tests/Tickets.Api.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/Sample/Tickets/Tickets.Tests/Extensions/Reservations/ReservationExtensions.cs
+++ b/Sample/Tickets/Tickets.Tests/Extensions/Reservations/ReservationExtensions.cs
@@ -17,7 +17,6 @@ internal static class ReservationExtensions
         reservation.Id.Should().Be(id);
         reservation.Number.Should().Be(number);
         reservation.SeatId.Should().Be(seatId);
-        reservation.Version.Should().Be(1);
 
         return reservation;
     }

--- a/Sample/Tickets/Tickets.Tests/Reservations/CancellingReservation/CancelReservationTests.cs
+++ b/Sample/Tickets/Tickets.Tests/Reservations/CancellingReservation/CancelReservationTests.cs
@@ -23,7 +23,6 @@ public class CancelReservationTests
 
         // Then
         reservation.Status.Should().Be(ReservationStatus.Cancelled);
-        reservation.Version.Should().Be(2);
 
         var @event = reservation.PublishedEvent<ReservationCancelled>();
 

--- a/Sample/Tickets/Tickets.Tests/Reservations/ChangingReservationSeat/ChangeSeatTests.cs
+++ b/Sample/Tickets/Tickets.Tests/Reservations/ChangingReservationSeat/ChangeSeatTests.cs
@@ -24,7 +24,6 @@ public class ChangeSeatTests
 
         // Then
         reservation.SeatId.Should().Be(newSeatId);
-        reservation.Version.Should().Be(2);
 
         var @event = reservation.PublishedEvent<ReservationSeatChanged>();
 

--- a/Sample/Tickets/Tickets.Tests/Reservations/ConfirmingReservation/ConfirmReservationTests.cs
+++ b/Sample/Tickets/Tickets.Tests/Reservations/ConfirmingReservation/ConfirmReservationTests.cs
@@ -23,7 +23,6 @@ public class ConfirmReservationTests
 
         // Then
         reservation.Status.Should().Be(ReservationStatus.Confirmed);
-        reservation.Version.Should().Be(2);
 
         var @event = reservation.PublishedEvent<ReservationConfirmed>();
 

--- a/Sample/Tickets/Tickets.Tests/Tickets.Tests.csproj
+++ b/Sample/Tickets/Tickets.Tests/Tickets.Tests.csproj
@@ -6,8 +6,8 @@
 
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Sample/Tickets/Tickets/Reservations/GettingReservationById/ReservationDetails.cs
+++ b/Sample/Tickets/Tickets/Reservations/GettingReservationById/ReservationDetails.cs
@@ -46,7 +46,7 @@ public class ReservationDetails
     }
 }
 
-public class ReservationDetailsProjection: AggregateProjection<ReservationDetails>
+public class ReservationDetailsProjection: SingleStreamAggregation<ReservationDetails>
 {
     public ReservationDetailsProjection()
     {

--- a/Sample/Tickets/Tickets/Reservations/GettingReservationById/ReservationDetails.cs
+++ b/Sample/Tickets/Tickets/Reservations/GettingReservationById/ReservationDetails.cs
@@ -24,25 +24,21 @@ public class ReservationDetails
         SeatId = @event.SeatId;
         Number = @event.Number;
         Status = ReservationStatus.Tentative;
-        Version++;
     }
 
     public void Apply(ReservationSeatChanged @event)
     {
         SeatId = @event.SeatId;
-        Version++;
     }
 
     public void Apply(ReservationConfirmed @event)
     {
         Status = ReservationStatus.Confirmed;
-        Version++;
     }
 
     public void Apply(ReservationCancelled @event)
     {
         Status = ReservationStatus.Cancelled;
-        Version++;
     }
 }
 

--- a/Sample/Tickets/Tickets/Reservations/GettingReservations/ReservationShortInfo.cs
+++ b/Sample/Tickets/Tickets/Reservations/GettingReservations/ReservationShortInfo.cs
@@ -26,7 +26,7 @@ public class ReservationShortInfo
     }
 }
 
-public class ReservationShortInfoProjection : AggregateProjection<ReservationShortInfo>
+public class ReservationShortInfoProjection : SingleStreamAggregation<ReservationShortInfo>
 {
     public ReservationShortInfoProjection()
     {

--- a/Sample/Tickets/Tickets/Reservations/Reservation.cs
+++ b/Sample/Tickets/Tickets/Reservations/Reservation.cs
@@ -94,24 +94,20 @@ public class Reservation : Aggregate
         SeatId = @event.SeatId;
         Number = @event.Number;
         Status = ReservationStatus.Tentative;
-        Version++;
     }
 
     public void Apply(ReservationSeatChanged @event)
     {
         SeatId = @event.SeatId;
-        Version++;
     }
 
     public void Apply(ReservationConfirmed @event)
     {
         Status = ReservationStatus.Confirmed;
-        Version++;
     }
 
     public void Apply(ReservationCancelled @event)
     {
         Status = ReservationStatus.Cancelled;
-        Version++;
     }
 }

--- a/Sample/Warehouse/Warehouse.Api.Tests/Warehouse.Api.Tests.csproj
+++ b/Sample/Warehouse/Warehouse.Api.Tests/Warehouse.Api.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/01-CreateStreamsTable/01-CreateStreamsTable.csproj
+++ b/Workshops/BuildYourOwnEventStore/01-CreateStreamsTable/01-CreateStreamsTable.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/02-CreateEventsTable/02-CreateEventsTable.csproj
+++ b/Workshops/BuildYourOwnEventStore/02-CreateEventsTable/02-CreateEventsTable.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/03-CreateAppendEventFunction/03-CreateAppendEventFunction.csproj
+++ b/Workshops/BuildYourOwnEventStore/03-CreateAppendEventFunction/03-CreateAppendEventFunction.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/03-OptimisticConcurrency/03-OptimisticConcurrency.csproj
+++ b/Workshops/BuildYourOwnEventStore/03-OptimisticConcurrency/03-OptimisticConcurrency.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/04-EventStoreMethods/04-EventStoreMethods.csproj
+++ b/Workshops/BuildYourOwnEventStore/04-EventStoreMethods/04-EventStoreMethods.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/05-StreamAggregation/05-StreamAggregation.csproj
+++ b/Workshops/BuildYourOwnEventStore/05-StreamAggregation/05-StreamAggregation.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/06-TimeTraveling/06-TimeTraveling.csproj
+++ b/Workshops/BuildYourOwnEventStore/06-TimeTraveling/06-TimeTraveling.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/07-AggregateAndRepository/07-AggregateAndRepository.csproj
+++ b/Workshops/BuildYourOwnEventStore/07-AggregateAndRepository/07-AggregateAndRepository.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/08-Snapshots/08-Snapshots.csproj
+++ b/Workshops/BuildYourOwnEventStore/08-Snapshots/08-Snapshots.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/09-Projections/09-Projections.csproj
+++ b/Workshops/BuildYourOwnEventStore/09-Projections/09-Projections.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/10-ProjectionsWithMarten/10-ProjectionsWithMarten.csproj
+++ b/Workshops/BuildYourOwnEventStore/10-ProjectionsWithMarten/10-ProjectionsWithMarten.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/10-ProjectionsWithMarten/Exercise10ProjectionsWithMarten.cs
+++ b/Workshops/BuildYourOwnEventStore/10-ProjectionsWithMarten/Exercise10ProjectionsWithMarten.cs
@@ -117,7 +117,7 @@ public class Exercise10ProjectionsWithMarten
         public decimal TotalAmount { get; set; }
     }
 
-    public class UserDashboardProjection: ViewProjection<UserDashboard, Guid>
+    public class UserDashboardProjection: MultiStreamAggregation<UserDashboard, Guid>
     {
         public UserDashboardProjection()
         {

--- a/Workshops/BuildYourOwnEventStore/EventStoreBasics.Tests/EventStoreBasics.Tests.csproj
+++ b/Workshops/BuildYourOwnEventStore/EventStoreBasics.Tests/EventStoreBasics.Tests.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/BuildYourOwnEventStore/EventStoreBasics.Tests/Exercise10ProjectionsWithMarten.cs
+++ b/Workshops/BuildYourOwnEventStore/EventStoreBasics.Tests/Exercise10ProjectionsWithMarten.cs
@@ -115,7 +115,7 @@ public class UserDashboard
     public decimal TotalAmount { get; set; }
 }
 
-public class UserDashboardProjection: ViewProjection<UserDashboard, Guid>
+public class UserDashboardProjection: MultiStreamAggregation<UserDashboard, Guid>
 {
     public UserDashboardProjection()
     {

--- a/Workshops/BuildYourOwnEventStore/EventStoreBasics/EventStoreBasics.csproj
+++ b/Workshops/BuildYourOwnEventStore/EventStoreBasics/EventStoreBasics.csproj
@@ -7,7 +7,7 @@
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-      <PackageReference Include="Marten" Version="5.3.1" />
+      <PackageReference Include="Marten" Version="5.5.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Simple.Migrations" Version="0.9.21" />
     </ItemGroup>

--- a/Workshops/BuildYourOwnEventStore/Tools/Tools.csproj
+++ b/Workshops/BuildYourOwnEventStore/Tools/Tools.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Simple.Migrations" Version="0.9.21" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Workshops/IntroductionToEventSourcing/01-EventsDefinition/01-EventsDefinition.csproj
+++ b/Workshops/IntroductionToEventSourcing/01-EventsDefinition/01-EventsDefinition.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/02-GettingStateFromEvents/02-GettingStateFromEvents.csproj
+++ b/Workshops/IntroductionToEventSourcing/02-GettingStateFromEvents/02-GettingStateFromEvents.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/03-AppendingEvents.Marten/03-AppendingEvents.Marten.csproj
+++ b/Workshops/IntroductionToEventSourcing/03-AppendingEvents.Marten/03-AppendingEvents.Marten.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/04-AppendingEvents.EventStoreDB/04-AppendingEvents.EventStoreDB.csproj
+++ b/Workshops/IntroductionToEventSourcing/04-AppendingEvents.EventStoreDB/04-AppendingEvents.EventStoreDB.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/05-GettingStateFromEvents.Marten/05-GettingStateFromEvents.Marten.csproj
+++ b/Workshops/IntroductionToEventSourcing/05-GettingStateFromEvents.Marten/05-GettingStateFromEvents.Marten.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/06-GettingStateFromEvents.EventStoreDB/06-GettingStateFromEvents.EventStoreDB.csproj
+++ b/Workshops/IntroductionToEventSourcing/06-GettingStateFromEvents.EventStoreDB/06-GettingStateFromEvents.EventStoreDB.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/07-BusinessLogic/07-BusinessLogic.csproj
+++ b/Workshops/IntroductionToEventSourcing/07-BusinessLogic/07-BusinessLogic.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/08-BusinessLogic.Marten/08-BusinessLogic.Marten.csproj
+++ b/Workshops/IntroductionToEventSourcing/08-BusinessLogic.Marten/08-BusinessLogic.Marten.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/09-BusinessLogic.EventStoreDB/09-BusinessLogic.EventStoreDB.csproj
+++ b/Workshops/IntroductionToEventSourcing/09-BusinessLogic.EventStoreDB/09-BusinessLogic.EventStoreDB.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/10-OptimisticConcurrency.Marten/10-OptimisticConcurrency.Marten.csproj
+++ b/Workshops/IntroductionToEventSourcing/10-OptimisticConcurrency.Marten/10-OptimisticConcurrency.Marten.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/10-OptimisticConcurrency.Marten/Immutable/OptimisticConcurrencyTests.cs
+++ b/Workshops/IntroductionToEventSourcing/10-OptimisticConcurrency.Marten/Immutable/OptimisticConcurrencyTests.cs
@@ -110,6 +110,7 @@ public class OptimisticConcurrencyTests: MartenTest
             }
         );
         exception.Should().BeOfType<EventStreamUnexpectedMaxEventIdException>();
+        ReOpenSession();
 
         var shoppingCart = await DocumentSession.Get<ShoppingCart>(shoppingCartId, CancellationToken.None);
 

--- a/Workshops/IntroductionToEventSourcing/10-OptimisticConcurrency.Marten/Mixed/OptimisticConcurrencyTests.cs
+++ b/Workshops/IntroductionToEventSourcing/10-OptimisticConcurrency.Marten/Mixed/OptimisticConcurrencyTests.cs
@@ -125,6 +125,7 @@ public class OptimisticConcurrencyTests: MartenTest
             }
         );
         exception.Should().BeOfType<EventStreamUnexpectedMaxEventIdException>();
+        ReOpenSession();
 
         var shoppingCart = await DocumentSession.Get<ShoppingCart>(shoppingCartId, CancellationToken.None);
 

--- a/Workshops/IntroductionToEventSourcing/10-OptimisticConcurrency.Marten/Mutable/OptimisticConcurrencyTests.cs
+++ b/Workshops/IntroductionToEventSourcing/10-OptimisticConcurrency.Marten/Mutable/OptimisticConcurrencyTests.cs
@@ -113,6 +113,7 @@ public class OptimisticConcurrencyTests: MartenTest
             }
         );
         exception.Should().BeOfType<EventStreamUnexpectedMaxEventIdException>();
+        ReOpenSession();
 
         var shoppingCart = await DocumentSession.Get<ShoppingCart>(shoppingCartId, CancellationToken.None);
 

--- a/Workshops/IntroductionToEventSourcing/11-OptimisticConcurrency.EventStoreDB/11-OptimisticConcurrency.EventStoreDB.csproj
+++ b/Workshops/IntroductionToEventSourcing/11-OptimisticConcurrency.EventStoreDB/11-OptimisticConcurrency.EventStoreDB.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/12-Projections.SingleStream/12-Projections.SingleStream.csproj
+++ b/Workshops/IntroductionToEventSourcing/12-Projections.SingleStream/12-Projections.SingleStream.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/13-Projections.SingleStream.Idempotency/13-Projections.SingleStream.Idempotency.csproj
+++ b/Workshops/IntroductionToEventSourcing/13-Projections.SingleStream.Idempotency/13-Projections.SingleStream.Idempotency.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/14-Projections.SingleStream.EventualConsistency/14-Projections.SingleStream.EventualConsistency.csproj
+++ b/Workshops/IntroductionToEventSourcing/14-Projections.SingleStream.EventualConsistency/14-Projections.SingleStream.EventualConsistency.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/01-EventsDefinition/01-EventsDefinition.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/01-EventsDefinition/01-EventsDefinition.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/02-GettingStateFromEvents/02-GettingStateFromEvents.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/02-GettingStateFromEvents/02-GettingStateFromEvents.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/03-AppendingEvents.Marten/03-AppendingEvents.Marten.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/03-AppendingEvents.Marten/03-AppendingEvents.Marten.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/04-AppendingEvents.EventStoreDB/04-AppendingEvents.EventStoreDB.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/04-AppendingEvents.EventStoreDB/04-AppendingEvents.EventStoreDB.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/05-GettingStateFromEvents.Marten/05-GettingStateFromEvents.Marten.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/05-GettingStateFromEvents.Marten/05-GettingStateFromEvents.Marten.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/06-GettingStateFromEvents.EventStoreDB/06-GettingStateFromEvents.EventStoreDB.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/06-GettingStateFromEvents.EventStoreDB/06-GettingStateFromEvents.EventStoreDB.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/07-BusinessLogic/07-BusinessLogic.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/07-BusinessLogic/07-BusinessLogic.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/08-BusinessLogic.Marten/08-BusinessLogic.Marten.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/08-BusinessLogic.Marten/08-BusinessLogic.Marten.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/09-BusinessLogic.EventStoreDB/09-BusinessLogic.EventStoreDB.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/09-BusinessLogic.EventStoreDB/09-BusinessLogic.EventStoreDB.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/10-OptimisticConcurrency.Marten/10-OptimisticConcurrency.Marten.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/10-OptimisticConcurrency.Marten/10-OptimisticConcurrency.Marten.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/10-OptimisticConcurrency.Marten/Immutable/OptimisticConcurrencyTests.cs
+++ b/Workshops/IntroductionToEventSourcing/Solved/10-OptimisticConcurrency.Marten/Immutable/OptimisticConcurrencyTests.cs
@@ -109,6 +109,7 @@ public class OptimisticConcurrencyTests: MartenTest
             }
         );
         exception.Should().BeOfType<EventStreamUnexpectedMaxEventIdException>();
+        ReOpenSession();
 
         var shoppingCart = await DocumentSession.Get<ShoppingCart>(shoppingCartId, CancellationToken.None);
 

--- a/Workshops/IntroductionToEventSourcing/Solved/10-OptimisticConcurrency.Marten/Mixed/OptimisticConcurrencyTests.cs
+++ b/Workshops/IntroductionToEventSourcing/Solved/10-OptimisticConcurrency.Marten/Mixed/OptimisticConcurrencyTests.cs
@@ -124,6 +124,7 @@ public class OptimisticConcurrencyTests: MartenTest
             }
         );
         exception.Should().BeOfType<EventStreamUnexpectedMaxEventIdException>();
+        ReOpenSession();
 
         var shoppingCart = await DocumentSession.Get<ShoppingCart>(shoppingCartId, CancellationToken.None);
 

--- a/Workshops/IntroductionToEventSourcing/Solved/10-OptimisticConcurrency.Marten/Mutable/OptimisticConcurrencyTests.cs
+++ b/Workshops/IntroductionToEventSourcing/Solved/10-OptimisticConcurrency.Marten/Mutable/OptimisticConcurrencyTests.cs
@@ -112,6 +112,7 @@ public class OptimisticConcurrencyTests: MartenTest
             }
         );
         exception.Should().BeOfType<EventStreamUnexpectedMaxEventIdException>();
+        ReOpenSession();
 
         var shoppingCart = await DocumentSession.Get<ShoppingCart>(shoppingCartId, CancellationToken.None);
 

--- a/Workshops/IntroductionToEventSourcing/Solved/11-OptimisticConcurrency.EventStoreDB/11-OptimisticConcurrency.EventStoreDB.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/11-OptimisticConcurrency.EventStoreDB/11-OptimisticConcurrency.EventStoreDB.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/12-Projections.SingleStream/12-Projections.SingleStream.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/12-Projections.SingleStream/12-Projections.SingleStream.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/13-Projections.SingleStream.Idempotency/13-Projections.SingleStream.Idempotency.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/13-Projections.SingleStream.Idempotency/13-Projections.SingleStream.Idempotency.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Workshops/IntroductionToEventSourcing/Solved/14-Projections.SingleStream.EventualConsistency/14-Projections.SingleStream.EventualConsistency.csproj
+++ b/Workshops/IntroductionToEventSourcing/Solved/14-Projections.SingleStream.EventualConsistency/14-Projections.SingleStream.EventualConsistency.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Marten" Version="5.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Marten" Version="5.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
1. Aligned also Marten projections naming to latest convention:
- `AggregateProjection` to `SingleStreamAggregation`,
- `ViewProjection` to `MultiStreamAggregation`

2. Used convention-based version assignment on stream aggregation and single-stream projections.