### PR TITLE
Fix for CustomerIncidentsSummaryGrouper Issue in Helpdesk sample

### DIFF
--- a/Sample/Helpdesk/Helpdesk.Api/Incidents/GetCustomerIncidentsSummary/IncidentSummary.cs
+++ b/Sample/Helpdesk/Helpdesk.Api/Incidents/GetCustomerIncidentsSummary/IncidentSummary.cs
@@ -50,14 +50,14 @@ public class CustomerIncidentsSummaryGrouper: IAggregateGrouper<Guid>
 {
     private readonly Type[] eventTypes =
     {
-        typeof(IEvent<IncidentResolved>), typeof(IEvent<ResolutionAcknowledgedByCustomer>),
-        typeof(IEvent<IncidentClosed>)
+        typeof(IncidentResolved), typeof(ResolutionAcknowledgedByCustomer),
+        typeof(IncidentClosed)
     };
 
     public async Task Group(IQuerySession session, IEnumerable<IEvent> events, ITenantSliceGroup<Guid> grouping)
     {
         var filteredEvents = events
-            .Where(ev => eventTypes.Contains(ev.GetType()))
+            .Where(ev => eventTypes.Contains(ev.EventType))
             .ToList();
 
         if (!filteredEvents.Any())


### PR DESCRIPTION
Fix for this issue: https://github.com/oskardudycz/EventSourcing.NetCore/issues/172

``
{
  "Id": "6e369857-b645-4acf-8961-41b07c918de5",
  "Closed": 0,
  "Pending": 4,
  "Resolved": 0,
  "Acknowledged": 1
}
``

Now ``/incidents-summary`` API is working as it should