### PR TITLE
Configured static analysis and applied ConfigureAwait(false) to Core classes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -156,3 +156,41 @@ csharp_space_between_method_call_empty_parameter_list_parentheses = false
 # Wrapping preferences
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
+
+
+###############################
+# Reliability Inspections     #
+###############################
+
+# CA2012: Use ValueTasks correctly
+dotnet_diagnostic.CA2012.severity = error
+
+# VSTHRD002 Avoid problematic synchronous waits
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# VSTHRD011 Use AsyncLazy<T>
+dotnet_diagnostic.VSTHRD011.severity = warning
+
+# VSTHRD100 Avoid async void methods
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# VSTHRD101 Avoid unsupported async delegates
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# VSTHRD102 Implement internal logic asynchronously
+dotnet_diagnostic.VSTHRD102.severity = error
+
+# VSTHRD103 Call async methods when in an async method
+dotnet_diagnostic.VSTHRD103.severity = error
+
+# VSTHRD110 Observe result of async calls
+dotnet_diagnostic.VSTHRD110.severity = warning
+
+# VSTHRD111 Use .ConfigureAwait(bool)
+dotnet_diagnostic.VSTHRD111.severity = error
+
+# VSTHRD112 Implement System.IAsyncDisposable
+dotnet_diagnostic.VSTHRD112.severity = error
+
+# VSTHRD200 Use Async suffix for async methods
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/Core.Build.props
+++ b/Core.Build.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <PropertyGroup>
+        <AnalysisModeReliability>true</AnalysisModeReliability>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="All" Condition=" '$(TargetFrawework)' == 'netstandard2.0' "/>
+    </ItemGroup>
+</Project>

--- a/Core.ElasticSearch/Core.ElasticSearch.csproj
+++ b/Core.ElasticSearch/Core.ElasticSearch.csproj
@@ -6,15 +6,16 @@
 
 
     <ItemGroup>
-        <PackageReference Include="NEST" Version="7.17.5" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="NEST" Version="7.17.5"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Core\Core.csproj" />
+        <ProjectReference Include="..\Core\Core.csproj"/>
     </ItemGroup>
 
+    <Import Project="../Core.Build.props"/>
 </Project>

--- a/Core.ElasticSearch/Projections/ElasticSearchProjection.cs
+++ b/Core.ElasticSearch/Projections/ElasticSearchProjection.cs
@@ -28,7 +28,7 @@ public class ElasticSearchProjection<TEvent, TView> : IEventHandler<EventEnvelop
         var id = getId(eventEnvelope.Data);
         var indexName = IndexNameMapper.ToIndexName<TView>();
 
-        var entity = (await elasticClient.GetAsync<TView>(id, i => i.Index(indexName), ct))?.Source ??
+        var entity = (await elasticClient.GetAsync<TView>(id, i => i.Index(indexName), ct).ConfigureAwait(false))?.Source ??
                      (TView) Activator.CreateInstance(typeof(TView), true)!;
 
         entity.When(eventEnvelope);
@@ -37,7 +37,7 @@ public class ElasticSearchProjection<TEvent, TView> : IEventHandler<EventEnvelop
             entity,
             i => i.Index(indexName).Id(id).VersionType(VersionType.External).Version((long)eventEnvelope.Metadata.StreamPosition),
             ct
-        );
+        ).ConfigureAwait(false);
     }
 }
 

--- a/Core.ElasticSearch/Repository/ElasticSearchRepository.cs
+++ b/Core.ElasticSearch/Repository/ElasticSearchRepository.cs
@@ -26,7 +26,7 @@ public class ElasticSearchRepository<T>: IElasticSearchRepository<T> where T : c
 
     public async Task<T?> Find(Guid id, CancellationToken cancellationToken)
     {
-        var response = await elasticClient.GetAsync<T>(id, ct: cancellationToken);
+        var response = await elasticClient.GetAsync<T>(id, ct: cancellationToken).ConfigureAwait(false);
         return response?.Source;
     }
 

--- a/Core.EventStoreDB/Core.EventStoreDB.csproj
+++ b/Core.EventStoreDB/Core.EventStoreDB.csproj
@@ -6,16 +6,17 @@
 
 
     <ItemGroup>
-        <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Core\Core.csproj" />
+        <ProjectReference Include="..\Core\Core.csproj"/>
     </ItemGroup>
 
+    <Import Project="../Core.Build.props"/>
 </Project>

--- a/Core.EventStoreDB/Events/AggregateStreamExtensions.cs
+++ b/Core.EventStoreDB/Events/AggregateStreamExtensions.cs
@@ -22,7 +22,7 @@ public static class AggregateStreamExtensions
             cancellationToken: cancellationToken
         );
 
-        if (await readResult.ReadState == ReadState.StreamNotFound)
+        if (await readResult.ReadState.ConfigureAwait(false) == ReadState.StreamNotFound)
             return null;
 
         var aggregate = (T)Activator.CreateInstance(typeof(T), true)!;

--- a/Core.EventStoreDB/Repository/EventStoreDBRepository.cs
+++ b/Core.EventStoreDB/Repository/EventStoreDBRepository.cs
@@ -45,7 +45,7 @@ public class EventStoreDBRepository<T>: IEventStoreDBRepository<T> where T : cla
                     StreamState.NoStream,
                     GetEventsToStore(aggregate, TelemetryPropagator.GetPropagationContext(activity)),
                     cancellationToken: ct
-                );
+                ).ConfigureAwait(false);
                 return result.NextExpectedStreamRevision.ToUInt64();
             },
             token
@@ -63,7 +63,7 @@ public class EventStoreDBRepository<T>: IEventStoreDBRepository<T> where T : cla
                     nextVersion,
                     eventsToAppend,
                     cancellationToken: ct
-                );
+                ).ConfigureAwait(false);
                 return result.NextExpectedStreamRevision.ToUInt64();
             },
             token
@@ -81,7 +81,7 @@ public class EventStoreDBRepository<T>: IEventStoreDBRepository<T> where T : cla
                     nextVersion,
                     eventsToAppend,
                     cancellationToken: ct
-                );
+                ).ConfigureAwait(false);
                 return result.NextExpectedStreamRevision.ToUInt64();
             },
             token

--- a/Core.EventStoreDB/Repository/RepositoryExtensions.cs
+++ b/Core.EventStoreDB/Repository/RepositoryExtensions.cs
@@ -11,7 +11,7 @@ public static class RepositoryExtensions
         CancellationToken ct
     ) where T : class, IAggregate
     {
-        var entity = await repository.Find(id, ct);
+        var entity = await repository.Find(id, ct).ConfigureAwait(false);
 
         return entity ?? throw AggregateNotFoundException.For<T>(id);
     }
@@ -24,10 +24,10 @@ public static class RepositoryExtensions
         CancellationToken ct = default
     ) where T : class, IAggregate
     {
-        var entity = await repository.Get(id, ct);
+        var entity = await repository.Get(id, ct).ConfigureAwait(false);
 
         action(entity);
 
-        return await repository.Update(entity, expectedVersion, ct);
+        return await repository.Update(entity, expectedVersion, ct).ConfigureAwait(false);
     }
 }

--- a/Core.EventStoreDB/Subscriptions/EventStoreDBSubscriptionCheckpointRepository.cs
+++ b/Core.EventStoreDB/Subscriptions/EventStoreDBSubscriptionCheckpointRepository.cs
@@ -22,12 +22,12 @@ public class EventStoreDBSubscriptionCheckpointRepository: ISubscriptionCheckpoi
         var result = eventStoreClient.ReadStreamAsync(Direction.Backwards, streamName, StreamPosition.End, 1,
             cancellationToken: ct);
 
-        if (await result.ReadState == ReadState.StreamNotFound)
+        if (await result.ReadState.ConfigureAwait(false) == ReadState.StreamNotFound)
         {
             return null;
         }
 
-        ResolvedEvent? @event = await result.FirstOrDefaultAsync(ct);
+        ResolvedEvent? @event = await result.FirstOrDefaultAsync(ct).ConfigureAwait(false);
 
         return @event?.Deserialize<CheckpointStored>()?.Position;
     }
@@ -46,7 +46,7 @@ public class EventStoreDBSubscriptionCheckpointRepository: ISubscriptionCheckpoi
                 StreamState.StreamExists,
                 eventToAppend,
                 cancellationToken: ct
-            );
+            ).ConfigureAwait(false);
         }
         catch (WrongExpectedVersionException)
         {
@@ -58,7 +58,7 @@ public class EventStoreDBSubscriptionCheckpointRepository: ISubscriptionCheckpoi
                 StreamState.NoStream,
                 new StreamMetadata(1),
                 cancellationToken: ct
-            );
+            ).ConfigureAwait(false);
 
             // append event again expecting stream to not exist
             await eventStoreClient.AppendToStreamAsync(
@@ -66,7 +66,7 @@ public class EventStoreDBSubscriptionCheckpointRepository: ISubscriptionCheckpoi
                 StreamState.NoStream,
                 eventToAppend,
                 cancellationToken: ct
-            );
+            ).ConfigureAwait(false);
         }
     }
 

--- a/Core.Kafka/Consumers/KafkaConsumer.cs
+++ b/Core.Kafka/Consumers/KafkaConsumer.cs
@@ -51,7 +51,7 @@ public class KafkaConsumer: IExternalEventConsumer
             while (!cancellationToken.IsCancellationRequested)
             {
                 // consume event from Kafka
-                await ConsumeNextEvent(consumer, cancellationToken);
+                await ConsumeNextEvent(consumer, cancellationToken).ConfigureAwait(false);
             }
         }
         catch (Exception e)
@@ -96,7 +96,7 @@ public class KafkaConsumer: IExternalEventConsumer
                 async (_, ct) =>
                 {
                     // publish event to internal event bus
-                    await eventBus.Publish(eventEnvelope, ct);
+                    await eventBus.Publish(eventEnvelope, ct).ConfigureAwait(false);
 
                     consumer.Commit();
                 },
@@ -118,7 +118,7 @@ public class KafkaConsumer: IExternalEventConsumer
                     Kind = ActivityKind.Consumer
                 },
                 token
-            );
+            ).ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/Core.Kafka/Core.Kafka.csproj
+++ b/Core.Kafka/Core.Kafka.csproj
@@ -5,14 +5,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Confluent.Kafka" Version="1.9.3" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Confluent.Kafka" Version="1.9.3"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Core\Core.csproj" />
+        <ProjectReference Include="..\Core\Core.csproj"/>
     </ItemGroup>
 
+    <Import Project="../Core.Build.props"/>
 </Project>

--- a/Core.Kafka/Producers/KafkaProducer.cs
+++ b/Core.Kafka/Producers/KafkaProducer.cs
@@ -63,7 +63,7 @@ public class KafkaProducer: IExternalEventProducer
                     Kind = ActivityKind.Producer
                 },
                 token
-            );
+            ).ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/Core.Marten/Core.Marten.csproj
+++ b/Core.Marten/Core.Marten.csproj
@@ -5,16 +5,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Marten" Version="6.0.0-alpha.3" />
-        <PackageReference Include="MediatR" Version="11.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Marten" Version="6.0.0-alpha.3"/>
+        <PackageReference Include="MediatR" Version="11.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Core.Serialization\Core.Serialization.csproj" />
-      <ProjectReference Include="..\Core\Core.csproj" />
+        <ProjectReference Include="..\Core.Serialization\Core.Serialization.csproj"/>
+        <ProjectReference Include="..\Core\Core.csproj"/>
     </ItemGroup>
 
+    <Import Project="../Core.Build.props"/>
 </Project>

--- a/Core.Marten/ExternalProjections/MartenExternalProjection.cs
+++ b/Core.Marten/ExternalProjections/MartenExternalProjection.cs
@@ -25,7 +25,7 @@ public class MartenExternalProjection<TEvent, TView>: IEventHandler<EventEnvelop
     {
         var (@event, eventMetadata) = eventEnvelope;
 
-        var entity = await session.LoadAsync<TView>(getId(@event), ct) ??
+        var entity = await session.LoadAsync<TView>(getId(@event), ct).ConfigureAwait(false) ??
                      (TView)Activator.CreateInstance(typeof(TView), true)!;
 
         var eventLogPosition = eventMetadata.LogPosition;
@@ -39,7 +39,7 @@ public class MartenExternalProjection<TEvent, TView>: IEventHandler<EventEnvelop
 
         session.Store(entity);
 
-        await session.SaveChangesAsync(ct);
+        await session.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 }
 

--- a/Core.Marten/Repository/MartenRepository.cs
+++ b/Core.Marten/Repository/MartenRepository.cs
@@ -47,7 +47,7 @@ public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggrega
                     events
                 );
 
-                await documentSession.SaveChangesAsync(ct);
+                await documentSession.SaveChangesAsync(ct).ConfigureAwait(false);
 
                 return (long)events.Length;
             },
@@ -71,7 +71,7 @@ public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggrega
                     events
                 );
 
-                await documentSession.SaveChangesAsync(ct);
+                await documentSession.SaveChangesAsync(ct).ConfigureAwait(false);
 
                 return nextVersion;
             },
@@ -95,7 +95,7 @@ public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggrega
                     events
                 );
 
-                await documentSession.SaveChangesAsync(ct);
+                await documentSession.SaveChangesAsync(ct).ConfigureAwait(false);
 
                 return nextVersion;
             },
@@ -121,7 +121,7 @@ public class MartenRepository<T>: IMartenRepository<T> where T : class, IAggrega
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to inject trace context.");
+            logger.LogError(ex, "Failed to inject trace context");
         }
     }
 }

--- a/Core.Marten/Repository/RepositoryExtensions.cs
+++ b/Core.Marten/Repository/RepositoryExtensions.cs
@@ -11,7 +11,7 @@ public static class RepositoryExtensions
         CancellationToken cancellationToken = default
     ) where T : class, IAggregate
     {
-        var entity = await repository.Find(id, cancellationToken);
+        var entity = await repository.Find(id, cancellationToken).ConfigureAwait(false);
 
         return entity ?? throw AggregateNotFoundException.For<T>(id);
     }
@@ -24,10 +24,10 @@ public static class RepositoryExtensions
         CancellationToken cancellationToken = default
     ) where T : class, IAggregate
     {
-        var entity = await repository.Get(id, cancellationToken);
+        var entity = await repository.Get(id, cancellationToken).ConfigureAwait(false);
 
         action(entity);
 
-        return await repository.Update(entity, expectedVersion, cancellationToken);
+        return await repository.Update(entity, expectedVersion, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Core.Marten/Subscriptions/MartenEventPublisher.cs
+++ b/Core.Marten/Subscriptions/MartenEventPublisher.cs
@@ -48,7 +48,8 @@ public class MartenEventPublisher: IMartenEventsConsumer
                         parentContext
                     );
 
-                    await eventBus.Publish(EventEnvelopeFactory.From(@event.Data, eventMetadata), ct);
+                    await eventBus.Publish(EventEnvelopeFactory.From(@event.Data, eventMetadata), ct)
+                        .ConfigureAwait(false);
                 },
                 new StartActivityOptions
                 {
@@ -56,7 +57,7 @@ public class MartenEventPublisher: IMartenEventsConsumer
                     Parent = parentContext.ActivityContext
                 },
                 cancellationToken
-            );
+            ).ConfigureAwait(false);
         }
     }
 

--- a/Core.Marten/Subscriptions/MartenSubscription.cs
+++ b/Core.Marten/Subscriptions/MartenSubscription.cs
@@ -35,7 +35,7 @@ public class MartenSubscription: IProjection
         {
             foreach (var consumer in consumers)
             {
-                await consumer.ConsumeAsync(operations, streams, ct);
+                await consumer.ConsumeAsync(operations, streams, ct).ConfigureAwait(false);
             }
         }
         catch (Exception exc)

--- a/Core.Serialization/Core.Serialization.csproj
+++ b/Core.Serialization/Core.Serialization.csproj
@@ -5,7 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
     </ItemGroup>
 
+    <Import Project="../Core.Build.props"/>
 </Project>

--- a/Core.Testing/Core.Testing.csproj
+++ b/Core.Testing/Core.Testing.csproj
@@ -21,4 +21,6 @@
     <ItemGroup>
       <ProjectReference Include="..\Core\Core.csproj" />
     </ItemGroup>
+
+    <Import Project="../Core.Build.props" />
 </Project>

--- a/Core.Testing/EventListener.cs
+++ b/Core.Testing/EventListener.cs
@@ -21,7 +21,7 @@ public class EventListener: IEventBus
     public async Task Publish(IEventEnvelope eventEnvelope, CancellationToken ct)
     {
         eventsLog.PublishedEvents.Add(eventEnvelope);
-        await eventBus.Publish(eventEnvelope, ct);
+        await eventBus.Publish(eventEnvelope, ct).ConfigureAwait(false);
     }
 }
 

--- a/Core.Testing/TestWebApplicationFactory.cs
+++ b/Core.Testing/TestWebApplicationFactory.cs
@@ -52,7 +52,7 @@ public class TestWebApplicationFactory<TProject>: WebApplicationFactory<TProject
         using var scope = Services.CreateScope();
         var eventBus = scope.ServiceProvider.GetRequiredService<IEventBus>();
 
-        await eventBus.Publish(eventEnvelope, ct);
+        await eventBus.Publish(eventEnvelope, ct).ConfigureAwait(false);
     }
 
     public IReadOnlyCollection<TEvent> PublishedInternalEventsOfType<TEvent>() =>
@@ -82,7 +82,7 @@ public class TestWebApplicationFactory<TProject>: WebApplicationFactory<TProject
                     throw;
             }
 
-            await Task.Delay(retryIntervalInMs);
+            await Task.Delay(retryIntervalInMs).ConfigureAwait(false);
             retryCount--;
         } while (!finished);
     }

--- a/Core.WebApi/Core.WebApi.csproj
+++ b/Core.WebApi/Core.WebApi.csproj
@@ -13,4 +13,6 @@
       <ProjectReference Include="..\Core\Core.csproj" />
     </ItemGroup>
 
+
+    <Import Project="../Core.Build.props" />
 </Project>

--- a/Core.WebApi/Middlewares/ExceptionHandling/ExceptionHandlingMiddleware.cs
+++ b/Core.WebApi/Middlewares/ExceptionHandling/ExceptionHandlingMiddleware.cs
@@ -25,11 +25,11 @@ public class ExceptionHandlingMiddleware
     {
         try
         {
-            await next(context);
+            await next(context).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            await HandleExceptionAsync(context, ex);
+            await HandleExceptionAsync(context, ex).ConfigureAwait(false);
         }
     }
 

--- a/Core.WebApi/OptimisticConcurrency/OptimisticConcurrencyMiddleware.cs
+++ b/Core.WebApi/OptimisticConcurrency/OptimisticConcurrencyMiddleware.cs
@@ -40,7 +40,7 @@ public class OptimisticConcurrencyMiddleware
             return Task.CompletedTask;
         });
 
-        await next(context);
+        await next(context).ConfigureAwait(false);
     }
 
     private void TryGetExpectedVersionFromRequestIfMatchHeader(

--- a/Core/BackgroundWorkers/BackgroundWorker.cs
+++ b/Core/BackgroundWorkers/BackgroundWorker.cs
@@ -22,7 +22,7 @@ public class BackgroundWorker: BackgroundService
         {
             await Task.Yield();
             logger.LogInformation("Background worker started");
-            await perform(stoppingToken);
+            await perform(stoppingToken).ConfigureAwait(false);
             logger.LogInformation("Background worker stopped");
         }, stoppingToken);
 }

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -5,21 +5,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="Polly" Version="7.2.3" />
-        <PackageReference Include="RestSharp" Version="108.0.2" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.9" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.9" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+        <PackageReference Include="Polly" Version="7.2.3"/>
+        <PackageReference Include="RestSharp" Version="108.0.2"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.9"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.9"/>
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1"/>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Core.Serialization\Core.Serialization.csproj" />
+        <ProjectReference Include="..\Core.Serialization\Core.Serialization.csproj"/>
     </ItemGroup>
+
+    <Import Project="../Core.Build.props"/>
 </Project>

--- a/Core/Events/AppendScope.cs
+++ b/Core/Events/AppendScope.cs
@@ -21,7 +21,7 @@ public class AppendScope<TVersion>: IAppendScope<TVersion> where TVersion: struc
 
     public async Task Do(Func<TVersion?, Task<TVersion>> handler)
     {
-        var nextVersion = await handler(getExpectedVersion());
+        var nextVersion = await handler(getExpectedVersion()).ConfigureAwait(false);
 
         setNextExpectedVersion(nextVersion);
     }

--- a/Core/Events/EventBus.cs
+++ b/Core/Events/EventBus.cs
@@ -51,7 +51,7 @@ public class EventBus: IEventBus
                 (_, token) => retryPolicy.ExecuteAsync(c => eventHandler.Handle(eventEnvelope, c), token),
                 activityOptions,
                 ct
-            );
+            ).ConfigureAwait(false);
         }
 
         // publish also just event data
@@ -68,7 +68,7 @@ public class EventBus: IEventBus
                 (_, token) => retryPolicy.ExecuteAsync(c => eventHandler.Handle(eventEnvelope.Data, c), token),
                 activityOptions,
                 ct
-            );
+            ).ConfigureAwait(false);
         }
     }
 

--- a/Core/Events/External/IExternaEventProducer.cs
+++ b/Core/Events/External/IExternaEventProducer.cs
@@ -22,11 +22,11 @@ public class EventBusDecoratorWithExternalProducer: IEventBus
 
     public async Task Publish(IEventEnvelope eventEnvelope, CancellationToken ct)
     {
-        await eventBus.Publish(eventEnvelope, ct);
+        await eventBus.Publish(eventEnvelope, ct).ConfigureAwait(false);
 
         if (eventEnvelope.Data is IExternalEvent)
         {
-            await externalEventProducer.Publish(eventEnvelope, ct);
+            await externalEventProducer.Publish(eventEnvelope, ct).ConfigureAwait(false);
         }
     }
 }

--- a/Core/OpenTelemetry/ActivityScope.cs
+++ b/Core/OpenTelemetry/ActivityScope.cs
@@ -70,7 +70,7 @@ public class ActivityScope: IActivityScope
 
         try
         {
-            await run(activity, ct);
+            await run(activity, ct).ConfigureAwait(false);
 
             activity?.SetStatus(ActivityStatusCode.Ok);
         }
@@ -92,7 +92,7 @@ public class ActivityScope: IActivityScope
 
         try
         {
-            var result = await run(activity, ct);
+            var result = await run(activity, ct).ConfigureAwait(false);
 
             activity?.SetStatus(ActivityStatusCode.Ok);
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS builder
 # Setup working directory for project
 WORKDIR /app
 
+COPY ./.editorconfig ./
 COPY ./Directory.Build.props ./
+COPY ./Core.Build.props ./
 COPY ./Core/Core.csproj ./Core/
 COPY ./Core.Serialization/Core.Serialization.csproj ./Core.Serialization/
 COPY ./Core.Marten/Core.Marten.csproj ./Core.Marten/

--- a/EventSourcing.NetCore.sln
+++ b/EventSourcing.NetCore.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 		Directory.Build.props = Directory.Build.props
 		Dockerfile = Dockerfile
+		Core.Build.props = Core.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core.Tests", "Core.Tests\Core.Tests.csproj", "{E1B97A7B-97C3-4C14-9BE6-ACE0AF45CE61}"


### PR DESCRIPTION
I decided to do that, as I already had deadlocks in testing code, plus it's good to set the example, as it's safer to have such code in core libraries. I didn't apply that to the business and API code.
Fixes #130