### PR TITLE
Problem with order initialization

### DIFF
--- a/Sample/ECommerce/Carts/Carts.Api.Tests/ShoppingCarts/Confirming/ConfirmShoppingCartTests.cs
+++ b/Sample/ECommerce/Carts/Carts.Api.Tests/ShoppingCarts/Confirming/ConfirmShoppingCartTests.cs
@@ -14,6 +14,10 @@ public class ConfirmShoppingCartFixture: ApiSpecification<Program>, IAsyncLifeti
 
     public readonly Guid ClientId = Guid.NewGuid();
 
+    public readonly ProductItemRequest ProductItem = new(Guid.NewGuid(), 1);
+
+    public decimal UnitPrice;
+
     public async Task InitializeAsync()
     {
         var openResponse = await Send(
@@ -23,6 +27,26 @@ public class ConfirmShoppingCartFixture: ApiSpecification<Program>, IAsyncLifeti
         await CREATED_WITH_DEFAULT_HEADERS(eTag: 1)(openResponse);
 
         ShoppingCartId = openResponse.GetCreatedId<Guid>();
+
+        var addResponse = await Send(
+            new ApiRequest(
+                POST,
+                URI($"/api/ShoppingCarts/{ShoppingCartId}/products"),
+                BODY(new AddProductRequest(ProductItem)),
+                HEADERS(IF_MATCH(1)))
+        );
+
+        await OK(addResponse);
+
+        var getResponse = await Send(
+            new ApiRequest(
+                GET_UNTIL(RESPONSE_ETAG_IS(2)),
+                URI($"/api/ShoppingCarts/{ShoppingCartId}")
+            )
+        );
+
+        var cartDetails = await getResponse.GetResultFromJson<ShoppingCartDetails>();
+        UnitPrice = cartDetails.ProductItems.Single().UnitPrice;
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -30,19 +54,18 @@ public class ConfirmShoppingCartFixture: ApiSpecification<Program>, IAsyncLifeti
 
 public class ConfirmShoppingCartTests: IClassFixture<ConfirmShoppingCartFixture>
 {
-
     private readonly ConfirmShoppingCartFixture API;
 
     public ConfirmShoppingCartTests(ConfirmShoppingCartFixture api) => API = api;
 
     [Fact]
     [Trait("Category", "Acceptance")]
-    public async Task Put_Should_Return_OK_And_Cancel_Shopping_Cart()
+    public async Task Put_Should_Return_OK_And_Confirm_Shopping_Cart()
     {
         await API
             .Given(
                 URI($"/api/ShoppingCarts/{API.ShoppingCartId}/confirmation"),
-                HEADERS(IF_MATCH(1))
+                HEADERS(IF_MATCH(2))
             )
             .When(PUT)
             .Then(OK);
@@ -51,18 +74,22 @@ public class ConfirmShoppingCartTests: IClassFixture<ConfirmShoppingCartFixture>
             .Given(
                 URI($"/api/ShoppingCarts/{API.ShoppingCartId}")
             )
-            .When(GET_UNTIL(RESPONSE_ETAG_IS(2)))
+            .When(GET_UNTIL(RESPONSE_ETAG_IS(3)))
             .Then(
                 OK,
                 RESPONSE_BODY(new ShoppingCartDetails
                 {
                     Id = API.ShoppingCartId,
                     Status = ShoppingCartStatus.Confirmed,
-                    ProductItems = new List<PricedProductItem>(),
                     ClientId = API.ClientId,
-                    Version = 2,
+                    ProductItems = new List<PricedProductItem>
+                    {
+                        PricedProductItem.Create(
+                            ProductItem.From(API.ProductItem.ProductId, API.ProductItem.Quantity),
+                            API.UnitPrice
+                        )
+                    },
+                    Version = 3,
                 }));
-
-        // API.PublishedExternalEventsOfType<CartFinalized>();
     }
 }

--- a/Sample/ECommerce/Carts/Carts.Tests/Builders/CartBuilder.cs
+++ b/Sample/ECommerce/Carts/Carts.Tests/Builders/CartBuilder.cs
@@ -1,11 +1,16 @@
+using Carts.Pricing;
 using Carts.ShoppingCarts;
+using Carts.ShoppingCarts.Products;
+using Carts.Tests.Stubs.Products;
 using Core.Aggregates;
 
 namespace Carts.Tests.Builders;
 
 internal class CartBuilder
 {
+    private readonly IProductPriceCalculator productPriceCalculator = new FakeProductPriceCalculator();
     private Func<ShoppingCart> build = () => new ShoppingCart();
+    private Func<ShoppingCart, ShoppingCart>? modify;
 
     public CartBuilder Opened()
     {
@@ -23,11 +28,24 @@ internal class CartBuilder
         return this;
     }
 
+    public CartBuilder WithProduct()
+    {
+        var productId = Guid.NewGuid();
+        const int quantity = 1;
+        modify += cart =>
+        {
+            cart.AddProduct(productPriceCalculator, ProductItem.From(productId, quantity));
+            return cart;
+        };
+        return this;
+    }
+
     public static CartBuilder Create() => new();
 
     public ShoppingCart Build()
     {
         var cart = build();
+        modify?.Invoke(cart);
         ((IAggregate)cart).DequeueUncommittedEvents();
         return cart;
     }

--- a/Sample/ECommerce/Carts/Carts.Tests/Carts/ConfirmingCart/ConfirmCartTests.cs
+++ b/Sample/ECommerce/Carts/Carts.Tests/Carts/ConfirmingCart/ConfirmCartTests.cs
@@ -16,6 +16,7 @@ public class ConfirmCartTests
         var cart = CartBuilder
             .Create()
             .Opened()
+            .WithProduct()
             .Build();
 
         // When
@@ -29,5 +30,21 @@ public class ConfirmCartTests
         @event.Should().NotBeNull();
         @event.Should().BeOfType<ShoppingCartConfirmed>();
         @event!.CartId.Should().Be(cart.Id);
+    }
+
+    [Fact]
+    public void ForEmptyCart_ShouldFail()
+    {
+        // Given
+        var emptyCart = CartBuilder
+            .Create()
+            .Opened()
+            .Build();
+
+        // When
+        Action confirmAction = () => emptyCart.Confirm();
+
+        // Then
+        confirmAction.Should().Throw<InvalidOperationException>();
     }
 }

--- a/Sample/ECommerce/Carts/Carts/ShoppingCarts/ShoppingCart.cs
+++ b/Sample/ECommerce/Carts/Carts/ShoppingCarts/ShoppingCart.cs
@@ -129,6 +129,9 @@ public class ShoppingCart: Aggregate
         if(Status != ShoppingCartStatus.Pending)
             throw new InvalidOperationException($"Confirming cart in '{Status}' status is not allowed.");
 
+        if (ProductItems.Count == 0)
+            throw new InvalidOperationException($"Confirming empty cart is not allowed.");
+
         var @event = ShoppingCartConfirmed.Create(Id, DateTime.UtcNow);
 
         Enqueue(@event);


### PR DESCRIPTION
`OrderInitialized` event is created in the asynchronous process after a cart is confirmed. It has to have at least one product in it. 
The cart could be confirmed without any products what would cause order initialization to fail silently.

Call stack:
```
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'Count')
   at Orders.Orders.InitializingOrder.OrderInitialized.Create(Guid orderId, Guid clientId, IReadOnlyList`1 productItems, Decimal totalPrice, DateTime initializedAt) in D:\dev\EventSourcing.NetCore\Orders\Orders\Orders\InitializingOrder\OrderInitialized.cs:line 25
   at Orders.Orders.Order..ctor(Guid id, Guid clientId, IReadOnlyList`1 productItems, Decimal totalPrice) in D:\dev\EventSourcing.NetCore\Orders\Orders\Orders\Order.cs:line 40
   at Orders.Orders.Order.Initialize(Guid orderId, Guid clientId, IReadOnlyList`1 productItems, Decimal totalPrice) in D:\dev\EventSourcing.NetCore\Orders\Orders\Orders\Order.cs:line 28
   at Orders.Orders.InitializingOrder.HandleInitializeOrder.<>c__DisplayClass3_0.<Handle>b__0(Nullable`1 _) in D:\dev\EventSourcing.NetCore\Orders\Orders\Orders\InitializingOrder\InitializeOrder.cs:line 56
   at Core.Events.AppendScope`1.Do(Func`2 handler) in D:\dev\EventSourcing.NetCore\Core\Core\Events\AppendScope.cs:line 24
   at Orders.Orders.InitializingOrder.HandleInitializeOrder.Handle(InitializeOrder command, CancellationToken cancellationToken) in D:\dev\EventSourcing.NetCore\Orders\Orders\Orders\InitializingOrder\InitializeOrder.cs:line 55
   at Core.Tracing.TracingCommandBusDecorator.Send[TCommand](TCommand command) in D:\dev\EventSourcing.NetCore\Core\Core\Tracing\TracingCommandBusDecorator.cs:line 23
```