### PR TITLE
Added various ways of running compatibility tests

### DIFF
--- a/Sample/EventsVersioning/ECommerce.V1/ECommerce.V1.csproj
+++ b/Sample/EventsVersioning/ECommerce.V1/ECommerce.V1.csproj
@@ -1,7 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <!--  Catches incompatibility with the NuGet.
+    Read more in: https://devblogs.microsoft.com/dotnet/package-validation/#validation-against-baseline-package-version
+    -->
+    <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.5.21302.8" />
+
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Ecommerce.V1</PackageId>
+        <Version>1.0.0</Version>
+        <!-- Ucomment if you have NuGet published. Set it to the previous major version -->
+        <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>-->
     </PropertyGroup>
-
 </Project>

--- a/Sample/EventsVersioning/EventsVersioning.Tests/EventsVersioning.Tests.csproj
+++ b/Sample/EventsVersioning/EventsVersioning.Tests/EventsVersioning.Tests.csproj
@@ -12,6 +12,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Verify.Xunit" Version="24.2.0" />
         <PackageReference Include="xunit" Version="2.8.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
             <PrivateAssets>all</PrivateAssets>

--- a/Sample/EventsVersioning/EventsVersioning.Tests/EventsVersioning.Tests.csproj
+++ b/Sample/EventsVersioning/EventsVersioning.Tests/EventsVersioning.Tests.csproj
@@ -12,6 +12,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
         <PackageReference Include="Verify.Xunit" Version="24.2.0" />
         <PackageReference Include="xunit" Version="2.8.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">

--- a/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/EventsSnapshotTests.ShoppingCartConfirmed_WithCompleteData_IsCompatible.verified.txt
+++ b/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/EventsSnapshotTests.ShoppingCartConfirmed_WithCompleteData_IsCompatible.verified.txt
@@ -1,0 +1,5 @@
+﻿{
+  ShoppingCartId: Guid_1,
+  ClientId: anonymised,
+  ConfirmedAt: DateTimeOffset_1
+}

--- a/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/EventsSnapshotTests.ShoppingCartConfirmed_WithOnlyRequiredData_IsCompatible.verified.txt
+++ b/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/EventsSnapshotTests.ShoppingCartConfirmed_WithOnlyRequiredData_IsCompatible.verified.txt
@@ -1,0 +1,4 @@
+﻿{
+  ShoppingCartId: Guid_1,
+  ConfirmedAt: DateTimeOffset_1
+}

--- a/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/EventsSnapshotTests.cs
+++ b/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/EventsSnapshotTests.cs
@@ -1,0 +1,34 @@
+using System.Runtime.CompilerServices;
+
+namespace EventsVersioning.Tests.SnapshotTesting;
+
+public class EventsSnapshotTests
+{
+    private record ShoppingCartConfirmed(
+        Guid ShoppingCartId,
+        string? ClientId,
+        DateTimeOffset ConfirmedAt
+    );
+
+    [Fact]
+    public Task ShoppingCartConfirmed_WithCompleteData_IsCompatible()
+    {
+        var @event = new ShoppingCartConfirmed(Guid.NewGuid(), "Oskar Dudycz", DateTimeOffset.UtcNow);
+        return Verify(@event);
+    }
+
+    [Fact]
+    public Task ShoppingCartConfirmed_WithOnlyRequiredData_IsCompatible()
+    {
+        var @event = new ShoppingCartConfirmed(Guid.NewGuid(), null, DateTimeOffset.UtcNow);
+        return Verify(@event);
+    }
+}
+// note this is optional, if you really need to
+// This is just showing that you can
+public static class StaticSettingsUsage
+{
+    [ModuleInitializer]
+    public static void Initialize() =>
+        VerifierSettings.AddScrubber(text => text.Replace("Oskar Dudycz", "anonymised"));
+}

--- a/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/PackageSnapshotTests.cs
+++ b/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/PackageSnapshotTests.cs
@@ -1,0 +1,15 @@
+using ECommerce.V1;
+using PublicApiGenerator;
+
+namespace EventsVersioning.Tests.SnapshotTesting;
+
+public class PackageSnapshotTests
+{
+    [Fact]
+    public Task my_assembly_has_no_public_api_changes()
+    {
+        var publicApi = typeof(ShoppingCartOpened).Assembly.GeneratePublicApi();
+
+        return Verify(publicApi);
+    }
+}

--- a/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/PackageSnapshotTests.my_assembly_has_no_public_api_changes.verified.txt
+++ b/Sample/EventsVersioning/EventsVersioning.Tests/SnapshotTesting/PackageSnapshotTests.my_assembly_has_no_public_api_changes.verified.txt
@@ -1,0 +1,46 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+namespace ECommerce.V1
+{
+    public class PricedProductItem : System.IEquatable<ECommerce.V1.PricedProductItem>
+    {
+        public PricedProductItem(ECommerce.V1.ProductItem ProductItem, decimal UnitPrice) { }
+        public ECommerce.V1.ProductItem ProductItem { get; init; }
+        public decimal UnitPrice { get; init; }
+    }
+    public class ProductItem : System.IEquatable<ECommerce.V1.ProductItem>
+    {
+        public ProductItem(System.Guid ProductId, int Quantity) { }
+        public System.Guid ProductId { get; init; }
+        public int Quantity { get; init; }
+    }
+    public class ProductItemAddedToShoppingCart : System.IEquatable<ECommerce.V1.ProductItemAddedToShoppingCart>
+    {
+        public ProductItemAddedToShoppingCart(System.Guid ShoppingCartId, ECommerce.V1.PricedProductItem ProductItem) { }
+        public ECommerce.V1.PricedProductItem ProductItem { get; init; }
+        public System.Guid ShoppingCartId { get; init; }
+    }
+    public class ProductItemRemovedFromShoppingCart : System.IEquatable<ECommerce.V1.ProductItemRemovedFromShoppingCart>
+    {
+        public ProductItemRemovedFromShoppingCart(System.Guid ShoppingCartId, ECommerce.V1.PricedProductItem ProductItem) { }
+        public ECommerce.V1.PricedProductItem ProductItem { get; init; }
+        public System.Guid ShoppingCartId { get; init; }
+    }
+    public class ShoppingCartConfirmed : System.IEquatable<ECommerce.V1.ShoppingCartConfirmed>
+    {
+        public ShoppingCartConfirmed(System.Guid ShoppingCartId, System.DateTime ConfirmedAt) { }
+        public System.DateTime ConfirmedAt { get; init; }
+        public System.Guid ShoppingCartId { get; init; }
+    }
+    public class ShoppingCartOpened : System.IEquatable<ECommerce.V1.ShoppingCartOpened>
+    {
+        public ShoppingCartOpened(System.Guid ShoppingCartId, System.Guid ClientId) { }
+        public System.Guid ClientId { get; init; }
+        public System.Guid ShoppingCartId { get; init; }
+    }
+    public enum ShoppingCartStatus
+    {
+        Pending = 1,
+        Confirmed = 2,
+        Cancelled = 3,
+    }
+}


### PR DESCRIPTION
This helps detect breaking changes in the API and can be useful for event schema versioning. Used tools:
1. [Verify](https://github.com/VerifyTests/Verify)  by @simoncropp for Snapshot Testing.
2. [PublicApiGenerator](https://github.com/PublicApiGenerator/PublicApiGenerator) by @PublicApiGenerator team.
3. [NuGet Package Validation](https://devblogs.microsoft.com/dotnet/package-validation/) from Microsoft to compare the new NuGet version with the published one.