### PR TITLE
Fixed handling of the LastProcessedPosition handling in EntityFrameworkProjection

### DIFF
--- a/Core.EventStoreDB.Tests/Commands/EventStoreDBAsyncCommandBusTests.cs
+++ b/Core.EventStoreDB.Tests/Commands/EventStoreDBAsyncCommandBusTests.cs
@@ -5,6 +5,7 @@ using Core.Events;
 using Core.EventStoreDB;
 using Core.EventStoreDB.Commands;
 using Core.EventStoreDB.Events;
+using Core.EventStoreDB.Subscriptions;
 using Core.OpenTelemetry;
 using Core.Testing;
 using EventStore.Client;
@@ -47,7 +48,7 @@ public class EventStoreDBAsyncCommandBusTests
             {
                 ConnectionString = "esdb://localhost:2113?tls=false"
             })
-            .AddEventStoreDBSubscriptionToAll()
+            .AddEventStoreDBSubscriptionToAll(new EventStoreDBSubscriptionToAllOptions(){SubscriptionId = "AsyncCommandBusTest"})
             .AddCommandHandler<AddUser, AddUserCommandHandler>(
                 _ => new AddUserCommandHandler(userIds)
             )

--- a/Core.EventStoreDB/Config.cs
+++ b/Core.EventStoreDB/Config.cs
@@ -56,7 +56,7 @@ public static class EventStoreDBConfigExtensions
 
     public static IServiceCollection AddEventStoreDBSubscriptionToAll(
         this IServiceCollection services,
-        EventStoreDBSubscriptionToAllOptions? subscriptionOptions = null,
+        EventStoreDBSubscriptionToAllOptions subscriptionOptions,
         bool checkpointToEventStoreDB = true)
     {
         if (checkpointToEventStoreDB)
@@ -77,11 +77,7 @@ public static class EventStoreDBConfigExtensions
 
                 return new BackgroundWorker(
                     logger,
-                    ct =>
-                        eventStoreDBSubscriptionToAll.SubscribeToAll(
-                            subscriptionOptions ?? new EventStoreDBSubscriptionToAllOptions(),
-                            ct
-                        )
+                    ct => eventStoreDBSubscriptionToAll.SubscribeToAll(subscriptionOptions, ct)
                 );
             }
         );

--- a/Core.EventStoreDB/Subscriptions/EventStoreDBSubscriptionToAll.cs
+++ b/Core.EventStoreDB/Subscriptions/EventStoreDBSubscriptionToAll.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using Core.Events;
 using Core.EventStoreDB.Events;
 using Core.OpenTelemetry;
-using Core.Threading;
 using EventStore.Client;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
@@ -12,7 +11,7 @@ namespace Core.EventStoreDB.Subscriptions;
 
 public class EventStoreDBSubscriptionToAllOptions
 {
-    public string SubscriptionId { get; set; } = "default";
+    public required string SubscriptionId { get; init; }
 
     public SubscriptionFilterOptions FilterOptions { get; set; } =
         new(EventTypeFilter.ExcludeSystemEvents());
@@ -34,8 +33,6 @@ public class EventStoreDBSubscriptionToAll(
 {
     private EventStoreDBSubscriptionToAllOptions subscriptionOptions = default!;
     private string SubscriptionId => subscriptionOptions.SubscriptionId;
-    private readonly object resubscribeLock = new();
-    private CancellationToken cancellationToken;
 
     public async Task SubscribeToAll(EventStoreDBSubscriptionToAllOptions subscriptionOptions, CancellationToken ct)
     {
@@ -43,7 +40,6 @@ public class EventStoreDBSubscriptionToAll(
         await Task.Yield();
 
         this.subscriptionOptions = subscriptionOptions;
-        cancellationToken = ct;
 
         logger.LogInformation("Subscription to all '{SubscriptionId}'", subscriptionOptions.SubscriptionId);
 

--- a/Core.Marten/ExternalProjections/MartenExternalProjection.cs
+++ b/Core.Marten/ExternalProjections/MartenExternalProjection.cs
@@ -38,7 +38,7 @@ public class MartenExternalProjection<TEvent, TView>(
         {
             await session.SaveChangesAsync(ct).ConfigureAwait(false);
         }
-        catch (MartenException martenException)
+        catch (Exception martenException)
             when (martenException.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
         {
             logger.LogWarning(martenException, "{ViewType} already exists. Ignoring", typeof(TView).Name);

--- a/Core/Projections/IProjection.cs
+++ b/Core/Projections/IProjection.cs
@@ -16,7 +16,11 @@ public interface IProjection<in TEvent>: IProjection where TEvent : class
     }
 }
 
-public interface IVersionedProjection: IProjection
+public interface ITrackLastProcessedPosition
 {
     public ulong LastProcessedPosition { get; set; }
+}
+
+public interface IVersionedProjection: IProjection, ITrackLastProcessedPosition
+{
 }

--- a/Sample/EventStoreDB/ECommerce/Carts/Carts.Api/Program.cs
+++ b/Sample/EventStoreDB/ECommerce/Carts/Carts.Api/Program.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Carts;
 using Core;
 using Core.EventStoreDB;
+using Core.EventStoreDB.Subscriptions;
 using Core.Exceptions;
 using Core.OpenTelemetry;
 using Core.WebApi.Middlewares.ExceptionHandling;
@@ -27,7 +28,7 @@ builder.Services
             WrongExpectedVersionException => exception.MapToProblemDetails(StatusCodes.Status412PreconditionFailed),
             _ => null
         })
-    .AddEventStoreDBSubscriptionToAll()
+    .AddEventStoreDBSubscriptionToAll(new EventStoreDBSubscriptionToAllOptions { SubscriptionId = "DDDESDB" })
     .AddCartsModule(builder.Configuration)
     .AddOptimisticConcurrencyMiddleware()
     .AddOpenTelemetry("Carts", OpenTelemetryOptions.Build(options =>

--- a/Sample/EventStoreDB/Simple/ECommerce.Api.Tests/ShoppingCartsApplicationFactory.cs
+++ b/Sample/EventStoreDB/Simple/ECommerce.Api.Tests/ShoppingCartsApplicationFactory.cs
@@ -8,17 +8,17 @@ namespace ECommerce.Api.Tests;
 
 public class ShoppingCartsApplicationFactory: TestWebApplicationFactory<Program>
 {
-    protected override IHost CreateHost(IHostBuilder builder)
-    {
-        var host = base.CreateHost(builder);
-
-        using var scope = host.Services.CreateScope();
-        using var context = scope.ServiceProvider.GetRequiredService<ECommerceDbContext>();
-        var database = context.Database;
-        database.ExecuteSqlRaw("TRUNCATE TABLE \"ShoppingCartDetailsProductItem\"");
-        database.ExecuteSqlRaw("TRUNCATE TABLE \"ShoppingCartShortInfo\"");
-        database.ExecuteSqlRaw("TRUNCATE TABLE \"ShoppingCartDetails\" CASCADE");
-
-        return host;
-    }
+    // protected override IHost CreateHost(IHostBuilder builder)
+    // {
+    //     var host = base.CreateHost(builder);
+    //
+    //     using var scope = host.Services.CreateScope();
+    //     using var context = scope.ServiceProvider.GetRequiredService<ECommerceDbContext>();
+    //     var database = context.Database;
+    //     database.ExecuteSqlRaw("TRUNCATE TABLE \"ShoppingCartDetailsProductItem\"");
+    //     database.ExecuteSqlRaw("TRUNCATE TABLE \"ShoppingCartShortInfo\"");
+    //     database.ExecuteSqlRaw("TRUNCATE TABLE \"ShoppingCartDetails\" CASCADE");
+    //
+    //     return host;
+    // }
 }

--- a/Sample/EventStoreDB/Simple/ECommerce.Api/Program.cs
+++ b/Sample/EventStoreDB/Simple/ECommerce.Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Core.EventStoreDB;
+using Core.EventStoreDB.Subscriptions;
 using Core.Exceptions;
 using Core.OpenTelemetry;
 using Core.WebApi.Middlewares.ExceptionHandling;
@@ -27,7 +28,7 @@ builder.Services
             WrongExpectedVersionException => exception.MapToProblemDetails(StatusCodes.Status412PreconditionFailed),
             _ => null
         })
-    .AddEventStoreDBSubscriptionToAll()
+    .AddEventStoreDBSubscriptionToAll(new EventStoreDBSubscriptionToAllOptions { SubscriptionId = "SimpleESDB"})
     .AddECommerceModule(builder.Configuration)
     .AddOptimisticConcurrencyMiddleware()
     .AddOpenTelemetry("Carts", OpenTelemetryOptions.Build(options =>

--- a/Sample/EventStoreDB/Simple/ECommerce.Core/Projections/EntityFrameworkProjection.cs
+++ b/Sample/EventStoreDB/Simple/ECommerce.Core/Projections/EntityFrameworkProjection.cs
@@ -118,10 +118,10 @@ public class UpdateProjection<TView, TEvent, TDbContext>(
         switch (view)
         {
             case null:
-                throw new InvalidOperationException($"{typeof(TView).Name} with id {viewId} wasn't found");
+                throw new InvalidOperationException($"{typeof(TView).Name} with id {viewId} wasn't found for event {typeof(TEvent).Name}");
             case ITrackLastProcessedPosition tracked when tracked.LastProcessedPosition <= eventEnvelope.Metadata.LogPosition:
                 logger.LogWarning(
-                    "{View} with id {ViewId} was already processe. LastProcessedPosition: {LastProcessedPosition}), event LogPosition: {LogPosition}",
+                    "{View} with id {ViewId} was already processed. LastProcessedPosition: {LastProcessedPosition}), event LogPosition: {LogPosition}",
                     typeof(TView).Name,
                     viewId,
                     tracked.LastProcessedPosition,

--- a/Sample/EventStoreDB/Simple/ECommerce.Core/Projections/EntityFrameworkProjection.cs
+++ b/Sample/EventStoreDB/Simple/ECommerce.Core/Projections/EntityFrameworkProjection.cs
@@ -91,10 +91,10 @@ public class AddProjection<TView, TEvent, TDbContext>(
             await dbContext.AddAsync(view, ct);
             await dbContext.SaveChangesAsync(ct);
         }
-        catch (PostgresException postgresException)
-            when (postgresException is { SqlState: PostgresErrorCodes.UniqueViolation })
+        catch (Exception updateException)
+            when (updateException.GetBaseException() is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
         {
-            logger.LogWarning(postgresException, "{ViewType} already exists. Ignoring", typeof(TView).Name);
+            logger.LogWarning(updateException, "{ViewType} already exists. Ignoring", typeof(TView).Name);
         }
     }
 }


### PR DESCRIPTION
I hope that'll finally solve those bloody flaky integration tests.

But even if not, then it's still needed to handle idempotency correctly.

Fixes #232 